### PR TITLE
CLOUD-1854: change active-mq cp to a glob

### DIFF
--- a/os-eap-activemq-rar/configure.sh
+++ b/os-eap-activemq-rar/configure.sh
@@ -4,7 +4,7 @@ set -e
 
 SOURCES_DIR=/tmp/artifacts
 
-cp -p ${SOURCES_DIR}/activemq-rar-5.11.0.redhat-621084.rar ${JBOSS_HOME}/standalone/deployments/activemq-rar.rar
+cp -p ${SOURCES_DIR}/activemq-rar-5.11.0.redhat-*.rar ${JBOSS_HOME}/standalone/deployments/activemq-rar.rar
 
 chown jboss:root ${JBOSS_HOME}/standalone/deployments/activemq-rar.rar
 chmod g+rwX ${JBOSS_HOME}/standalone/deployments/activemq-rar.rar


### PR DESCRIPTION
Adjust this script module so that it uses a glob to find the active-mq
RAR to copy into place; that way we can supply different .rar rebuild
versions without needing to modify this module further.

Signed-off-by: Jonathan Dowland <jdowland@redhat.com>