### PR TITLE
[CLOUD-2020] no_proxy configuration not properly translated to maven settings

### DIFF
--- a/s2i-common/common.sh
+++ b/s2i-common/common.sh
@@ -44,7 +44,10 @@ function configure_proxy_url() {
 
     local noProxy="${no_proxy:-${NO_PROXY}}"
     if [ -n "$noProxy" ]; then
-        HTTP_PROXY_NONPROXYHOSTS="${noProxy//,/|}"
+        noProxy="${noProxy//,/|}"
+        noProxy="${noProxy//|./|*.}"
+        noProxy="${noProxy/#./*.}"
+        HTTP_PROXY_NONPROXYHOSTS="${noProxy}"
     fi
   fi
 }


### PR DESCRIPTION
maven settings.xml generated is not correct when using domain.

If your proxy configuration include a proxy exclusion using an entire domain like this: 

NO_PROXY=.example.com,.example.net

the assemble script in /usr/local/s2i/bin/assemble translate the configuration in settings.xml like this:

<proxy>
...
<nonProxyHosts>.example.com|.example.net</nonProxyHosts>
...
</proxy>

But the correct translation is:

<proxy>
...
<nonProxyHosts>*.example.com|*.example.net</nonProxyHosts>
...
</proxy>

With the * (star) in front of the domain name.