### PR TITLE
[CLOUD-1350] Change AMQ_STORAGE_USAGE_LIMIT env var to AMQ_MEMORY_LIMIT

### DIFF
--- a/os-amq-launch/added/configure.sh
+++ b/os-amq-launch/added/configure.sh
@@ -129,7 +129,7 @@ function configureSSL() {
 }
 
 function configureStoreUsage() {
-  storeUsage=$(find_env "AMQ_STORAGE_USAGE_LIMIT" "100 gb")
+  storeUsage=$(find_env "AMQ_STORAGE_USAGE_LIMIT" "512 mb")
   sed -i "s|##### STORE_USAGE #####|${storeUsage}|" "$CONFIG_FILE"
 }
 

--- a/tests/features/amq/amq-common.feature
+++ b/tests/features/amq/amq-common.feature
@@ -36,8 +36,8 @@ Feature: Openshift AMQ tests
     Given XML namespace amq:http://activemq.apache.org/schema/core
     When container is started with env
        | variable                  | value           |
-       | AMQ_STORAGE_USAGE_LIMIT   | 200 gb          |
-    Then XML file /opt/amq/conf/activemq.xml should contain value 200 gb on XPath //amq:systemUsage/amq:storeUsage/amq:storeUsage/@limit
+       | AMQ_STORAGE_USAGE_LIMIT   | 10 gb           |
+    Then XML file /opt/amq/conf/activemq.xml should contain value 10 gb on XPath //amq:systemUsage/amq:storeUsage/amq:storeUsage/@limit
 
   Scenario: check authentication plugin configuration
     Given XML namespace amq:http://activemq.apache.org/schema/core


### PR DESCRIPTION
Link to JIRA: https://issues.jboss.org/browse/CLOUD-1350

Changes AMQ_STORAGE_USAGE_LIMIT to AMQ_MEMORY_LIMIT to reflect what this environment variable does in A-MQ configuration.