### PR TITLE
[CLOUD-1925] [EAP71] Set activemq thread pool system properties

### DIFF
--- a/tests/features/eap/7/eap_7_messaging.feature
+++ b/tests/features/eap/7/eap_7_messaging.feature
@@ -7,3 +7,11 @@ Feature: Openshift EAP Messaging Tests
     Then container log should contain Bound messaging object to jndi name java:/topic/HELLOWORLDMDBTopic
     Then container log should contain Started message driven bean 'HelloWorldQueueMDB' with 'activemq-ra.rar' resource adapter
     Then container log should contain Started message driven bean 'HelloWorldQTopicMDB' with 'activemq-ra.rar' resource adapter
+
+  Scenario: Check if thread pool default values respect cgroup limits
+    When container is started with args
+      | arg        | value    |
+      | cpu_quota  | 100000   |
+      | cpu-period | 100000   |
+    Then container log should contain -Dactivemq.artemis.client.global.thread.pool.max.size=8
+    Then container log should contain -Dactivemq.artemis.client.global.scheduled.thread.pool.core.size=5


### PR DESCRIPTION
JIRA link: https://issues.jboss.org/browse/CLOUD-1925

Currently, the JVM is not cgroup aware and cannot be trusted to generate default values for Artemis
threads pool arguments. The thread pool arguments must respect the limits of its containerized environment, and therefore are calculated using the original methods provided by Artemis and the resources reported by cgroups.

Signed-off-by: Kyle Liberti <kliberti@redhat.com>

Thanks for submitting your Pull Request!

Please make sure your PR meets following requirements:

- [x] Pull Request title is properly formatted: `[CLOUD-XYA] Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains description of the issue
- [x] Pull request does not include fixes for other issues than the main ticket
- [x] Attached commits represent unit of work and are properly formatted
- [x] You have read and agreed to the Developer Certificate of Origin (DCO) (see `CONTRIBUTING.md`)
- [x] Every commit contains `Signed-off-by: Your Name <yourname@redhat.com>` - use `git commit -s`
