### PR TITLE
[CLOUD-546] Change A-MQ Readiness probe to support IPv4 and IPv6

### DIFF
--- a/os-amq-launch/added/readinessProbe.sh
+++ b/os-amq-launch/added/readinessProbe.sh
@@ -20,9 +20,13 @@ import xml.etree.ElementTree
 from urlparse import urlsplit
 import socket
 import sys
+import os.path
 
 # calculate the open ports
-tcp_file = open("/proc/net/tcp6")
+if (os.path.isfile("/proc/net/tcp6")):
+    tcp_file = open("/proc/net/tcp6")
+else:
+    tcp_file = open("/proc/net/tcp")
 tcp_lines = tcp_file.readlines()
 header = tcp_lines.pop(0)
 tcp_file.close()


### PR DESCRIPTION
JIRA Link: https://issues.jboss.org/browse/CLOUD-546

A-MQ readiness probe looks for IPv6 open ports. This PR will check if IPv6 is enabled and if not will check IPv4 open ports

Signed-off-by: Ricardo M Oliveira <rmartine@rmartine.gru.redhat.com>

Thanks for submitting your Pull Request!

Please make sure your PR meets following requirements:

- [X] Pull Request title is properly formatted: `[CLOUD-XYA] Subject`
- [X] Pull Request contains link to the JIRA issue
- [X] Pull Request contains description of the issue
- [X] Pull request does not include fixes for other issues than the main ticket
- [X] Attached commits represent unit of work and are properly formatted
- [X] You have read and agreed to the Developer Certificate of Origin (DCO) (see `CONTRIBUTING.md`)
- [X] Every commit contains `Signed-off-by: Your Name <yourname@redhat.com>` - use `git commit -s`
