### PR TITLE
[CLOUD-1784] - Make the accessLog valve configurable

### DIFF
--- a/os-kieserver-launch/added/kieserver-launch.sh
+++ b/os-kieserver-launch/added/kieserver-launch.sh
@@ -25,6 +25,7 @@ CONFIGURE_SCRIPTS=(
   $JBOSS_HOME/bin/launch/jboss_modules_system_pkgs.sh
   $JBOSS_HOME/bin/launch/keycloak.sh
   $JBOSS_HOME/bin/launch/deploymentScanner.sh
+  $JBOSS_HOME/bin/launch/access_log_valve.sh
   /opt/run-java/proxy-options
 )
 


### PR DESCRIPTION
access_log_valve.sh should be executed on kieserver-launch.

Thanks for submitting your Pull Request!

Please make sure your PR meets following requirements:

- [ ] Pull Request title is properly formatted: `[CLOUD-XYA] Subject`
- [ ] Pull Request contains link to the JIRA issue
- [ ] Pull Request contains description of the issue
- [ ] Pull request does not include fixes for other issues than the main ticket
- [ ] Attached commits represent unit of work and are properly formatted
- [ ] You have read and agreed to the Developer Certificate of Origin (DCO) (see `CONTRIBUTING.md`)
- [ ] Every commit contains `Signed-off-by: Your Name <yourname@redhat.com>` - use `git commit -s`
