### PR TITLE
[CLOUD-1863] Add support for compatibility mode

### DIFF
--- a/os-jdg7-launch/added/launch/infinispan-config.sh
+++ b/os-jdg7-launch/added/launch/infinispan-config.sh
@@ -34,6 +34,8 @@ function clear_prefix() {
   unset ${prefix}_ID_TYPE
   unset ${prefix}_DATA_TYPE
   unset ${prefix}_TIMESTAMP_TYPE
+  unset ${prefix}_CACHE_PROTOCOL_COMPATIBILITY
+  unset ${prefix}_CACHE_COMPATIBILITY_MARSHALLER
 }
 
 function prepareEnv() {
@@ -345,8 +347,13 @@ function configure_cache() {
     cache="$cache mode=\"$CACHE_MODE\" $CACHE_QUEUE_SIZE $CACHE_QUEUE_FLUSH_INTERVAL $CACHE_REMOTE_TIMEOUT"
   fi
 
-  if [ "$CACHE_PROTOCOL_COMPATIBILITY" == "true" ]; then
-    compatibility="<compatibility enabled=\"true\"/>"
+  if [ "$(find_env "${prefix}_CACHE_PROTOCOL_COMPATIBILITY")" == "true" ]; then
+    local cache_compatibility_marshaller="$(find_env "${prefix}_CACHE_COMPATIBILITY_MARSHALLER")"
+    if [ -n "$cache_compatibility_marshaller" ]; then
+      compatibility="<compatibility enabled=\"true\" marshaller=\"$cache_compatibility_marshaller\"/>"
+    else
+      compatibility="<compatibility enabled=\"true\"/>"
+    fi
   fi
 
   cache="$cache $CACHE_START $CACHE_BATCHING $CACHE_STATISTICS  $CACHE_OWNERS $CACHE_SEGMENTS $CACHE_L1_LIFESPAN>$eviction $expiration $jdbcstore $indexing $cachesecurity $partitionhandling $locking $compatibility\

--- a/tests/features/datagrid/7.1/datagrid_compatibility_mode.feature
+++ b/tests/features/datagrid/7.1/datagrid_compatibility_mode.feature
@@ -1,0 +1,67 @@
+@jboss-datagrid-7/datagrid71-openshift
+Feature: OpenShift JDG Compatibility Mode tests
+
+  Scenario: Enabling Compatibility Mode test
+    When container is started with env
+       | variable                                | value      |
+       | CACHE_NAMES                             | MYAPPCACHE |
+       | MYAPPCACHE_CACHE_PROTOCOL_COMPATIBILITY | true       |
+    Then XML file /opt/datagrid/standalone/configuration/clustered-openshift.xml should contain value MYAPPCACHE on XPath //*[local-name()='distributed-cache']/@name
+    And XML file /opt/datagrid/standalone/configuration/clustered-openshift.xml should contain value true on XPath //*[local-name()='distributed-cache'][@name='MYAPPCACHE']/*[local-name()='compatibility']/@enabled
+    And container log should contain DGISPN0001: Started MYAPPCACHE cache from clustered container
+
+  Scenario: Enabling Compatibility Mode with Marshaller test
+    When container is started with env
+       | variable                                  | value                                                       |
+       | CACHE_NAMES                               | MYAPPCACHE                                                  |
+       | MYAPPCACHE_CACHE_PROTOCOL_COMPATIBILITY   | true                                                        |
+       | MYAPPCACHE_CACHE_COMPATIBILITY_MARSHALLER | org.infinispan.commons.marshall.JavaSerializationMarshaller |
+    Then XML file /opt/datagrid/standalone/configuration/clustered-openshift.xml should contain value MYAPPCACHE on XPath //*[local-name()='distributed-cache']/@name
+    And XML file /opt/datagrid/standalone/configuration/clustered-openshift.xml should contain value true on XPath //*[local-name()='distributed-cache'][@name='MYAPPCACHE']/*[local-name()='compatibility']/@enabled
+    And XML file /opt/datagrid/standalone/configuration/clustered-openshift.xml should contain value org.infinispan.commons.marshall.JavaSerializationMarshaller on XPath //*[local-name()='distributed-cache'][@name='MYAPPCACHE']/*[local-name()='compatibility']/@marshaller
+    And container log should contain DGISPN0001: Started MYAPPCACHE cache from clustered container
+
+  Scenario: Enabling Compatibility Mode in Selected Cache test
+    When container is started with env
+       | variable                                  | value                                                       |
+       | CACHE_NAMES                               | MYAPPCACHE1,MYAPPCACHE2                                     |
+       | MYAPPCACHE2_CACHE_PROTOCOL_COMPATIBILITY  | true                                                        |
+    Then XML file /opt/datagrid/standalone/configuration/clustered-openshift.xml should contain value MYAPPCACHE1 on XPath //*[local-name()='distributed-cache']/@name
+    And XML file /opt/datagrid/standalone/configuration/clustered-openshift.xml should contain value MYAPPCACHE2 on XPath //*[local-name()='distributed-cache']/@name
+    And XML file /opt/datagrid/standalone/configuration/clustered-openshift.xml should have 0 elements on XPath //*[local-name()='distributed-cache'][@name='MYAPPCACHE1']/*[local-name()='compatibility']
+    And XML file /opt/datagrid/standalone/configuration/clustered-openshift.xml should contain value true on XPath //*[local-name()='distributed-cache'][@name='MYAPPCACHE2']/*[local-name()='compatibility']/@enabled
+    And container log should contain DGISPN0001: Started MYAPPCACHE1 cache from clustered container
+    And container log should contain DGISPN0001: Started MYAPPCACHE2 cache from clustered container
+
+  Scenario: Enabling Compatibility Mode in Selected Cache with Marshaller test
+    When container is started with env
+       | variable                                   | value                                                        |
+       | CACHE_NAMES                                | MYAPPCACHE1,MYAPPCACHE2                                      |
+       | MYAPPCACHE1_CACHE_PROTOCOL_COMPATIBILITY   | true                                                         |
+       | MYAPPCACHE1_CACHE_COMPATIBILITY_MARSHALLER | org.infinispan.commons.marshall.jboss.GenericJBossMarshaller |
+    Then XML file /opt/datagrid/standalone/configuration/clustered-openshift.xml should contain value MYAPPCACHE1 on XPath //*[local-name()='distributed-cache']/@name
+    And XML file /opt/datagrid/standalone/configuration/clustered-openshift.xml should contain value MYAPPCACHE2 on XPath //*[local-name()='distributed-cache']/@name
+    And XML file /opt/datagrid/standalone/configuration/clustered-openshift.xml should contain value true on XPath //*[local-name()='distributed-cache'][@name='MYAPPCACHE1']/*[local-name()='compatibility']/@enabled
+    And XML file /opt/datagrid/standalone/configuration/clustered-openshift.xml should have 0 elements on XPath //*[local-name()='distributed-cache'][@name='MYAPPCACHE2']/*[local-name()='compatibility']
+    And XML file /opt/datagrid/standalone/configuration/clustered-openshift.xml should contain value org.infinispan.commons.marshall.jboss.GenericJBossMarshaller on XPath //*[local-name()='distributed-cache'][@name='MYAPPCACHE1']/*[local-name()='compatibility']/@marshaller
+    And container log should contain DGISPN0001: Started MYAPPCACHE1 cache from clustered container
+    And container log should contain DGISPN0001: Started MYAPPCACHE2 cache from clustered container
+
+  Scenario: Enabling Compatibility Mode in Selected Caches with Marshaller in Selected Cache test
+    When container is started with env
+       | variable                                   | value                                                        |
+       | CACHE_NAMES                                | MYAPPCACHE1,MYAPPCACHE2,MYAPPCACHE3                          |
+       | MYAPPCACHE1_CACHE_PROTOCOL_COMPATIBILITY   | true                                                         |
+       | MYAPPCACHE3_CACHE_PROTOCOL_COMPATIBILITY   | true                                                         |
+       | MYAPPCACHE3_CACHE_COMPATIBILITY_MARSHALLER | org.infinispan.commons.marshall.jboss.GenericJBossMarshaller |
+    Then XML file /opt/datagrid/standalone/configuration/clustered-openshift.xml should contain value MYAPPCACHE1 on XPath //*[local-name()='distributed-cache']/@name
+    And XML file /opt/datagrid/standalone/configuration/clustered-openshift.xml should contain value MYAPPCACHE2 on XPath //*[local-name()='distributed-cache']/@name
+    And XML file /opt/datagrid/standalone/configuration/clustered-openshift.xml should contain value MYAPPCACHE3 on XPath //*[local-name()='distributed-cache']/@name
+    And XML file /opt/datagrid/standalone/configuration/clustered-openshift.xml should contain value true on XPath //*[local-name()='distributed-cache'][@name='MYAPPCACHE1']/*[local-name()='compatibility']/@enabled
+    And XML file /opt/datagrid/standalone/configuration/clustered-openshift.xml should have 0 elements on XPath //*[local-name()='distributed-cache'][@name='MYAPPCACHE2']/*[local-name()='compatibility']
+    And XML file /opt/datagrid/standalone/configuration/clustered-openshift.xml should contain value true on XPath //*[local-name()='distributed-cache'][@name='MYAPPCACHE3']/*[local-name()='compatibility']/@enabled
+    And XML file /opt/datagrid/standalone/configuration/clustered-openshift.xml should contain value org.infinispan.commons.marshall.jboss.GenericJBossMarshaller on XPath //*[local-name()='distributed-cache'][@name='MYAPPCACHE3']/*[local-name()='compatibility']/@marshaller
+    And container log should contain DGISPN0001: Started MYAPPCACHE1 cache from clustered container
+    And container log should contain DGISPN0001: Started MYAPPCACHE2 cache from clustered container
+    And container log should contain DGISPN0001: Started MYAPPCACHE3 cache from clustered container
+


### PR DESCRIPTION
Issue: [CLOUD-1863](https://issues.jboss.org/browse/CLOUD-1863)

Add support for configuring compatibility mode for each configured cache through the use of env.
Creates two new env variables:

${prefix}_CACHE_PROTOCOL_COMPATIBILITY
- Optional, can be set for each configured cache. Enables/disables compatibility mode. Default is disabled, "true" will enable it.

${prefix}_CACHE_COMPATIBILITY_MARSHALLER
- Optional, can be set for each configured cache. Marshaller for use in compatibility mode, only will be considered if compatibility mode is enabled though the previous env. As of JDG 7.1, does not support the configuration of external marshallers, only internal ones (e.g. org.infinispan.commons.marshall.JavaSerializationMarshaller or org.infinispan.commons.marshall.jboss.GenericJBossMarshaller).

Please make sure your PR meets following requirements:

- [x] Pull Request title is properly formatted: `[CLOUD-XYA] Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains description of the issue
- [x] Pull request does not include fixes for other issues than the main ticket
- [x] Attached commits represent unit of work and are properly formatted
- [x] You have read and agreed to the Developer Certificate of Origin (DCO) (see `CONTRIBUTING.md`)
- [x] Every commit contains `Signed-off-by: Your Name <yourname@redhat.com>` - use `git commit -s`
