### PR TITLE
[CLOUD-2068] make refresh-interval for timer data-store configurable

### DIFF
--- a/os-eap-launch/added/launch/datasource-common.sh
+++ b/os-eap-launch/added/launch/datasource-common.sh
@@ -186,8 +186,9 @@ function generate_datasource_common() {
   fi
 
   if [ -n "$TIMER_SERVICE_DATA_STORE" -a "$TIMER_SERVICE_DATA_STORE" = "${service_name}" ]; then
+    local refreshInterval=${TIMER_SERVICE_DATA_STORE_REFRESH_INTERVAL:--1}
     inject_timer_service ${pool_name}_ds
-    inject_datastore $pool_name $jndi_name $driver
+    inject_datastore $pool_name $jndi_name $driver $refreshInterval
   fi
 
   echo $ds | sed ':a;N;$!ba;s|\n|\\n|g'
@@ -333,13 +334,22 @@ function inject_timer_service() {
 # $1 - service name
 # $2 - datasource jndi name
 # $3 - datasource databasename
+# $4 - refresh interval
 function inject_datastore() {
   local servicename="${1}"
   local jndi_name="${2}"
   local databasename="${3}"
+  local refresh_interval="${4}"
 
-  local datastore="<database-data-store name=\"${servicename}_ds\" datasource-jndi-name=\"${jndi_name}\" database=\"${databasename}\" partition=\"${servicename}_part\"/>\
+  # only set the refresh-interval if configured (it is only supported in EAP 7+)
+  if [ "$refresh_interval" = "-1" ]; then
+    local datastore="<database-data-store name=\"${servicename}_ds\" datasource-jndi-name=\"${jndi_name}\" database=\"${databasename}\" partition=\"${servicename}_part\" />\
         <!-- ##DATASTORES## -->"
+  else
+    local datastore="<database-data-store name=\"${servicename}_ds\" datasource-jndi-name=\"${jndi_name}\" database=\"${databasename}\" partition=\"${servicename}_part\" refresh-interval=\"${refresh_interval}\"/>\
+        <!-- ##DATASTORES## -->"
+  fi
+
   sed -i "s|<!-- ##DATASTORES## -->|${datastore}|" $CONFIG_FILE
 }
 


### PR DESCRIPTION
The refresh-interval is not supported by EAP 6.4.x, so can not be added
by default.

Signed-off-by: Petr Široký <psiroky@redhat.com>

Second try, hopefully compatible with all the images now. Tried with EAP 6.4 and it works (as long as the env. var `TIMER_SERVICE_DATA_STORE_REFRESH_INTERVAL` is not set, which it should not for EAP 6.4 images as the refresh interval is not supported there).