### PR TITLE
Revert "CLOUD-2070 fix access to hsperfdata_jboss"

### DIFF
--- a/os-java-run/added/run-java.sh
+++ b/os-java-run/added/run-java.sh
@@ -224,18 +224,10 @@ get_exec_args() {
   fi
 }
 
-function configure_passwd() {
-  sed "/^jboss/s/[^:]*/$(id -u)/3" /etc/passwd > /tmp/passwd
-  cat /tmp/passwd > /etc/passwd
-  rm /tmp/passwd
-}
-
 # Start JVM
 startup() {
   # Initialize environment
   load_env $(get_script_dir)
-
-  configure_passwd
 
   local args
   cd ${JAVA_APP_DIR}

--- a/tests/features/java/java_s2i.feature
+++ b/tests/features/java/java_s2i.feature
@@ -276,10 +276,4 @@ Feature: Openshift OpenJDK S2I tests
   Scenario: Test that maven is executed in batch mode
     Given s2i build https://github.com/jboss-openshift/openshift-examples from spring-boot-sample-simple
     Then s2i build log should contain --batch-mode
-    And s2i build log should not contain \r          
-
-  Scenario: Check java perf dir owned by jboss (CLOUD-2070)
-    Given s2i build https://github.com/jboss-openshift/openshift-examples from spring-boot-sample-simple
-    Then run sh -c 'pgrep -x java | xargs -I{} jstat -gc {} 1000 1' in container and check its output for S0C
-    And run sh -c 'stat --printf="%U %G" /tmp/hsperfdata_jboss/' in container and check its output for jboss root
-   
+    And s2i build log should not contain \r             


### PR DESCRIPTION
The corresponding PR for openjdk broke the build of that image so we
are backing out the two changes until we can fix that.