### PR TITLE
[CLOUD-2061] bump rh-sso versions

### DIFF
--- a/os-eap64-sso/configure.sh
+++ b/os-eap64-sso/configure.sh
@@ -4,8 +4,8 @@ SCRIPT_DIR=$(dirname $0)
 ADDED_DIR=${SCRIPT_DIR}/added
 SOURCES_DIR="/tmp/artifacts"
 
-unzip -o $SOURCES_DIR/rh-sso-7.0.0-eap6-adapter.zip -d $JBOSS_HOME
-unzip -o $SOURCES_DIR/rh-sso-7.0.0-saml-eap6-adapter.zip -d $JBOSS_HOME
+unzip -o $SOURCES_DIR/rh-sso-7.1.0-eap6-adapter.zip -d $JBOSS_HOME
+unzip -o $SOURCES_DIR/rh-sso-7.1.2-saml-eap6-adapter.zip -d $JBOSS_HOME
 
 chown -R jboss:root $JBOSS_HOME
 chmod -R g+rwX $JBOSS_HOME

--- a/os-eap70-sso/configure.sh
+++ b/os-eap70-sso/configure.sh
@@ -4,8 +4,8 @@ SCRIPT_DIR=$(dirname $0)
 ADDED_DIR=${SCRIPT_DIR}/added
 SOURCES_DIR="/tmp/artifacts"
 
-unzip -o $SOURCES_DIR/rh-sso-7.0.0-eap7-adapter.zip -d $JBOSS_HOME
-unzip -o $SOURCES_DIR/rh-sso-7.0.0-saml-eap7-adapter.zip -d $JBOSS_HOME
+unzip -o $SOURCES_DIR/rh-sso-7.1.0-eap7-adapter.zip -d $JBOSS_HOME
+unzip -o $SOURCES_DIR/rh-sso-7.1.2-saml-eap7-adapter.zip -d $JBOSS_HOME
 
 chown -R jboss:root $JBOSS_HOME
 chmod -R g+rwX $JBOSS_HOME


### PR DESCRIPTION
7.0.0 is out-of-date. These are the latest built versions of the two
adapters available.

https://issues.jboss.org/browse/CLOUD-2061

Signed-off-by: Jonathan Dowland <jdowland@redhat.com>