### PR TITLE
WIP: [CLOUD-2195] [RH-SSO 7.1] Launch the RH-SSO 7.1 server with the generation of the XML configuration file history being disabled

### DIFF
--- a/os-sso71/added/openshift-launch.sh
+++ b/os-sso71/added/openshift-launch.sh
@@ -59,9 +59,10 @@ function clean_shutdown() {
 
 trap "clean_shutdown" TERM
 
+JBOSS_XML_HISTORY_ARGS="-Djboss.config.current-history-length=0 -Djboss.config.history-days=0"
 if [ -n "$SSO_IMPORT_FILE" ] && [ -f $SSO_IMPORT_FILE ]; then
-  $JBOSS_HOME/bin/standalone.sh -c standalone-openshift.xml -bmanagement 127.0.0.1 $JBOSS_HA_ARGS ${JBOSS_MESSAGING_ARGS} -Dkeycloak.migration.action=import -Dkeycloak.migration.provider=singleFile -Dkeycloak.migration.file=${SSO_IMPORT_FILE} -Dkeycloak.migration.strategy=IGNORE_EXISTING ${JAVA_PROXY_OPTIONS} &
+  $JBOSS_HOME/bin/standalone.sh -c standalone-openshift.xml -bmanagement 127.0.0.1 ${JBOSS_XML_HISTORY_ARGS} ${JBOSS_HA_ARGS} ${JBOSS_MESSAGING_ARGS} -Dkeycloak.migration.action=import -Dkeycloak.migration.provider=singleFile -Dkeycloak.migration.file=${SSO_IMPORT_FILE} -Dkeycloak.migration.strategy=IGNORE_EXISTING ${JAVA_PROXY_OPTIONS} &
 else
-  $JBOSS_HOME/bin/standalone.sh -c standalone-openshift.xml -bmanagement 127.0.0.1 $JBOSS_HA_ARGS ${JBOSS_MESSAGING_ARGS} ${JAVA_PROXY_OPTIONS} &
+  $JBOSS_HOME/bin/standalone.sh -c standalone-openshift.xml -bmanagement 127.0.0.1 ${JBOSS_XML_HISTORY_ARGS} ${JBOSS_HA_ARGS} ${JBOSS_MESSAGING_ARGS} ${JAVA_PROXY_OPTIONS} &
 fi
 wait $!


### PR DESCRIPTION
<br/>
<b>WIP Don't merge yet (this doesn't work with WildFly Core 2.1.18.Final-redhat-1, investigating)</b> 

This allows RH-SSO 7.1 for OpenShift pod to start properly also on environments using overlay(fs) as the docker storage driver

Fixes: https://issues.jboss.org/browse/CLOUD-2195
Fixes: https://github.com/openshift/openshift-ansible/issues/2823

Signed-off-by: Jan Lieskovsky <jlieskov@redhat.com>

PTAL

Thank you, Jan