### PR TITLE
CLOUD-2207 ignore CONTAINER_SECURITY_CUSTOM_ROLE_MAPPER_CLASS if CONT…

### DIFF
--- a/os-jdg7-launch/added/launch/infinispan-config.sh
+++ b/os-jdg7-launch/added/launch/infinispan-config.sh
@@ -491,7 +491,7 @@ function configure_container_security() {
         local CONTAINER_SECURITY_CUSTOM_ROLE_MAPPER_CLASS="class=\"$CONTAINER_SECURITY_CUSTOM_ROLE_MAPPER_CLASS\""
       fi
       local rolemapper="\
-                        <$CONTAINER_SECURITY_ROLE_MAPPER $CONTAINER_SECURITY_CUSTOM_ROLE_MAPPER_CLASS/>"
+                        <$CONTAINER_SECURITY_ROLE_MAPPER/>"
     fi
 
     if [ -n "$CONTAINER_SECURITY_ROLES" ]; then


### PR DESCRIPTION
…AINER_SECURITY_ROLE_MAPPER != custom-role-mapper to not create invalid XML

https://issues.jboss.org/browse/CLOUD-2207