### PR TITLE
CLOUD-2211 Updates for JDG 7.1.1

### DIFF
--- a/os-eap-launch/added/launch/jgroups.sh
+++ b/os-eap-launch/added/launch/jgroups.sh
@@ -36,7 +36,8 @@ function configure_jgroups_encryption() {
       product=`read_product_name`
       version=`read_product_version`
 
-      if [ "$product" == "Red Hat JBoss Enterprise Application Platform" -a "$(version_compare $version '6.4.4.GA')" == "newer" ]; then
+      if [ "$product" == "Red Hat JBoss Enterprise Application Platform" -a "$(version_compare $version '6.4.4.GA')" == "newer" ] ||
+         [ "$product" == "Red Hat JBoss Data Grid" -a "$(version_compare $version '7.1.0')" == "newer" ]; then
         # For new JGroups we need to use SYM_ENCRYPT protocol
         jgroups_encrypt="\
           <protocol type=\"SYM_ENCRYPT\">\

--- a/tests/features/datagrid/7.1/datagrid.feature
+++ b/tests/features/datagrid/7.1/datagrid.feature
@@ -11,7 +11,7 @@ Feature: Openshift DataGrid tests
        | CONTAINER_SECURITY_ROLES                      | admin=ALL             |
        | DEFAULT_CACHE_SECURITY_AUTHORIZATION_ENABLED  | true                  |
        | DEFAULT_CACHE_SECURITY_AUTHORIZATION_ROLES    | admin                 |
-    Then container log should contain WFLYSRV0025: Data Grid 7.1.0
+    Then container log should contain WFLYSRV0025
     Then run /opt/datagrid/bin/readinessProbe.sh in container once
     Then run /opt/datagrid/bin/livenessProbe.sh in container once
 


### PR DESCRIPTION
https://issues.jboss.org/browse/CLOUD-2211

This PR includes JDG 7.1.1 Test fix and `Encryption` protocol fix. 

Depending what other products will do, we might want to collapse the product `if` statement to JGroups version comparison (>= JGroups 4 use `SYM_ENCRYPT` for example). However this requires a longer thought and making sure we don't break anything. I might file a separate JIRA for it but for the time being (chasing by the release date), I would stick to a simple `or` statement.