### PR TITLE
WIP: [CLOUD-2195] When using a storage driver other than 'devicemapper', clean up the left-over content of the history directory prior running the RH-SSO 7.1 server

### DIFF
--- a/os-sso71/added/launch/overlayfs_check_d_type_support.py
+++ b/os-sso71/added/launch/overlayfs_check_d_type_support.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python
+#
+# Python script helper to check overlayfs d_type support is enabled for specified directory path
+#
+# Author: Original Python implementation of d_type support checker written by Prashanth Pai <ppai@redhat.com>
+#         Modified for purpose of xPaaS images by Jan Lieskovsky <jlieskov@redhat.com>
+#
+
+import ctypes
+import os
+import sys
+from ctypes.util import find_library
+
+(DT_UNKNOWN, DT_DIR,) = (0, 4,)
+
+class linux_dirent64(ctypes.Structure):
+    _fields_ = (
+        ('d_ino', ctypes.c_uint64),
+        ('d_off', ctypes.c_int64),
+        ('d_reclen', ctypes.c_ushort),
+        ('d_type', ctypes.c_ubyte),
+        ('d_name', ctypes.c_char * 256),
+    )
+
+
+class linux_DIR(ctypes.Structure):
+    pass
+
+
+if __name__ == '__main__':
+
+    if len(sys.argv) < 2:
+        print "%s: Enter directory path to check for d_type support!" % sys.argv[0]
+        exit(1)
+
+    dpath = sys.argv[1]
+    if not os.path.isdir(dpath):
+        errmsg = "%s: Invalid directory path '%s': " % (sys.argv[0], dpath)
+        if not os.path.exists(dpath):
+            errmsg += "The directory does not exist!"
+        else:
+            errmsg += "Not a directory!"
+        print errmsg
+        exit(1)
+
+    dpath_fstype = os.popen("stat -f -c %%T %s" % dpath).read().rstrip()
+    if dpath_fstype != "overlayfs":
+        print "%s: File system type for \"%s\" directory path is not overlayfs!" % (sys.argv[0], dpath)
+        exit(1)
+
+    libc = ctypes.CDLL(find_library('c'), use_errno=True)
+
+    libc.opendir.argtypes = [ctypes.c_char_p]
+    libc.opendir.restype = ctypes.POINTER(linux_DIR)
+    libc.readdir.restype = ctypes.POINTER(linux_dirent64)
+
+    dirp = libc.opendir(dpath)
+    while True:
+        e = libc.readdir(dirp)
+        if not e:
+            break
+        # The backing filesystem is formatted with ftype=0 (d_type support is not enabled)
+        if e.contents.d_type == DT_UNKNOWN:
+            print "%s: The backing filesystem is formatted without d_type support!" % sys.argv[0]
+            exit(1)
+
+    # The backing filesystem is formatted with ftype=1 (d_type support enabled)
+    exit(0)

--- a/os-sso71/added/openshift-launch.sh
+++ b/os-sso71/added/openshift-launch.sh
@@ -48,6 +48,24 @@ CONFIGURE_SCRIPTS=(
 
 source $JBOSS_HOME/bin/launch/configure.sh
 
+XML_HISTORY_CURRENT_DIR="$JBOSS_HOME/standalone/configuration/standalone_xml_history/current"
+if [ -d "$XML_HISTORY_CURRENT_DIR" ]; then
+  XML_HISTORY_CURRENT_DIR_FSTYPE=$(stat -f -c %T "$XML_HISTORY_CURRENT_DIR")
+  if [ "$XML_HISTORY_CURRENT_DIR_FSTYPE" != "xfs" ]; then
+    rm -rf "$XML_HISTORY_CURRENT_DIR"
+    if [ "$?" -ne "0" ]; then
+      echo "Error trying to clean up the history directory!"
+      if [ "$XML_HISTORY_CURRENT_DIR_FSTYPE" = "overlayfs" ]; then
+        if ! "$JBOSS_HOME/bin/launch/overlayfs_check_d_type_support.py" "$XML_HISTORY_CURRENT_DIR"; then
+          echo "The backing filesystem is formatted without d_type support."
+          echo "Reformat the filesystem with ftype=1 to enable d_type support."
+        fi
+      fi 
+      exit 1
+    fi
+  fi
+fi
+
 echo "Running $JBOSS_IMAGE_NAME image, version $JBOSS_IMAGE_VERSION"
 
 # TERM signal handler


### PR DESCRIPTION
<b>Will rework this change yet, don't merge</b>

Also, if using overlay(fs) storage driver verify the backing filesystem was
formatted with d_type support enabled. Exit early if not, since this is unsupported
configuration

Fixes: https://issues.jboss.org/browse/CLOUD-2195
Fixes: https://github.com/openshift/openshift-ansible/issues/2823

Signed-off-by: Jan Lieskovsky <jlieskov@redhat.com>

PTAL

Thank you, Jan