### PR TITLE
[CLOUD-2221] configure KieLoginModule only for Business Central

### DIFF
--- a/os-bpmsuite-businesscentral/added/launch/bpmsuite-businesscentral.sh
+++ b/os-bpmsuite-businesscentral/added/launch/bpmsuite-businesscentral.sh
@@ -105,5 +105,8 @@ function configure_guvnor_settings() {
 
 function configure_misc_security() {
     add_management_interface_realm
-    configure_login_modules "org.kie.security.jaas.KieLoginModule" "optional" "deployment.ROOT.war"
+    # KieLoginModule breaks Decision Central; it needs to be added only for Business Central & Business Central Monitoring
+    if [ "$JBOSS_PRODUCT" = "bpmsuite-businesscentral" ] || [ "$JBOSS_PRODUCT" = "bpmsuite-businesscentral-monitoring" ]; then
+        configure_login_modules "org.kie.security.jaas.KieLoginModule" "optional" "deployment.ROOT.war"
+    fi
 }

--- a/tests/features/bpmsuite/businesscentral/configuration.feature
+++ b/tests/features/bpmsuite/businesscentral/configuration.feature
@@ -1,0 +1,8 @@
+@jboss-bpmsuite-7/bpmsuite70-businesscentral-openshift @jboss-bpmsuite-7/bpmsuite70-businesscentral-monitoring-openshift
+Feature: Business Central configuration tests
+
+  # https://issues.jboss.org/browse/CLOUD-2221
+  Scenario: Check KieLoginModule is configured
+      When container is ready
+
+      Then file /opt/eap/standalone/configuration/standalone-openshift.xml should contain <login-module code="org.kie.security.jaas.KieLoginModule"

--- a/tests/features/rhdm/decisioncentral/configuration.feature
+++ b/tests/features/rhdm/decisioncentral/configuration.feature
@@ -1,0 +1,8 @@
+@rhdm-7/rhdm70-decisioncentral-openshift
+Feature: Decision Central configuration tests
+
+  # https://issues.jboss.org/browse/CLOUD-2221
+  Scenario: Check KieLoginModule is _not_ configured
+      When container is ready
+
+      Then file /opt/eap/standalone/configuration/standalone-openshift.xml should not contain <login-module code="org.kie.security.jaas.KieLoginModule"


### PR DESCRIPTION
Thanks for submitting your Pull Request!

Please make sure your PR meets following requirements:

- [x] Pull Request title is properly formatted: `[CLOUD-XYA] Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains description of the issue
- [x] Pull request does not include fixes for other issues than the main ticket
- [x] Attached commits represent unit of work and are properly formatted
- [x] You have read and agreed to the Developer Certificate of Origin (DCO) (see `CONTRIBUTING.md`)
- [x] Every commit contains `Signed-off-by: Your Name <yourname@redhat.com>` - use `git commit -s`

This is definitely not an ideal solution. We should probably have generic set of common functions/modules and then specify which of them would be executed for the specific deliverables. But until that is in place this should be a sufficient workaround.