### PR TITLE
[CLOUD-2223] table prefix for jdbc object store table defined by default

### DIFF
--- a/os-eap7-launch/added/launch/tx-datasource.sh
+++ b/os-eap7-launch/added/launch/tx-datasource.sh
@@ -67,7 +67,9 @@ function generate_tx_datasource() {
 }
 
 function inject_jdbc_store() {
-  jdbcStore="<jdbc-store datasource-jndi-name=\"${1}ObjectStore\"/>"
+  local PREFIX='os\${jboss.node.name}'
+  [ -n "$JBOSS_NODE_NAME" ] && PREFIX="os${JBOSS_NODE_NAME//-/}"
+  jdbcStore="<jdbc-store datasource-jndi-name=\"${1}ObjectStore\"><action table-prefix=\"${PREFIX}\"/></jdbc-store>"
   sed -i "s|<!-- ##JDBC_STORE## -->|${jdbcStore}|" $CONFIG_FILE
 }
 

--- a/os-eap7-launch/added/openshift-launch.sh
+++ b/os-eap7-launch/added/openshift-launch.sh
@@ -14,10 +14,11 @@ CONFIGURE_SCRIPTS=(
   $JBOSS_HOME/bin/launch/configure_extensions.sh
   $JBOSS_HOME/bin/launch/passwd.sh
   $JBOSS_HOME/bin/launch/messaging.sh
+  # ha.sh run before datasource, it provides env variable used by txn objectstore
+  $JBOSS_HOME/bin/launch/ha.sh
   $JBOSS_HOME/bin/launch/datasource.sh
   $JBOSS_HOME/bin/launch/resource-adapter.sh
   $JBOSS_HOME/bin/launch/admin.sh
-  $JBOSS_HOME/bin/launch/ha.sh
   $JBOSS_HOME/bin/launch/jgroups.sh
   $JBOSS_HOME/bin/launch/https.sh
   $JBOSS_HOME/bin/launch/elytron.sh


### PR DESCRIPTION
When the object store is used as storage for transactions the table where txn data are saved should be unique for each pod. That's ensured by adding prefix to the table with txn records which is - `jbosststxtable`.

https://issues.jboss.org/browse/CLOUD-2223
