### PR TITLE
[CLOUD-2226] Use SYM_ENCRYPT instead of ENCRYPT

### DIFF
--- a/os-jdg7-launch/added/launch/jgroups.sh
+++ b/os-jdg7-launch/added/launch/jgroups.sh
@@ -1,0 +1,39 @@
+# only processes a single environment as the placeholder is not preserved
+
+function prepareEnv() {
+  unset JGROUPS_ENCRYPT_SECRET
+  unset JGROUPS_ENCRYPT_PASSWORD
+  unset JGROUPS_ENCRYPT_KEYSTORE_DIR
+  unset JGROUPS_ENCRYPT_KEYSTORE
+  unset JGROUPS_ENCRYPT_NAME
+}
+
+function configure() {
+  configure_jgroups_encryption
+}
+
+function configureEnv() {
+  configure
+}
+
+function configure_jgroups_encryption() {
+  jgroups_encrypt=""
+
+  if [ -n "${JGROUPS_ENCRYPT_SECRET}" ]; then
+    if [ -n "${JGROUPS_ENCRYPT_NAME}" -a -n "${JGROUPS_ENCRYPT_PASSWORD}" ] ; then
+      jgroups_encrypt="\
+        <protocol type=\"SYM_ENCRYPT\">\
+          <property name=\"provider\">SunJCE</property>\
+          <property name=\"sym_algorithm\">AES</property>\
+          <property name=\"encrypt_entire_message\">true</property>\
+          <property name=\"keystore_name\">${JGROUPS_ENCRYPT_KEYSTORE_DIR}/${JGROUPS_ENCRYPT_KEYSTORE}</property>\
+          <property name=\"store_password\">${JGROUPS_ENCRYPT_PASSWORD}</property>\
+          <property name=\"alias\">${JGROUPS_ENCRYPT_NAME}</property>\
+        </protocol>"
+    else
+      echo "WARNING! Partial JGroups encryption configuration, the communication within the cluster WILL NOT be encrypted."
+    fi
+  fi
+
+  sed -i "s|<!-- ##JGROUPS_ENCRYPT## -->|$jgroups_encrypt|g" "$CONFIG_FILE"
+}

--- a/os-jdg7-launch/configure.sh
+++ b/os-jdg7-launch/configure.sh
@@ -21,4 +21,5 @@ cp -p ${ADDED_DIR}/launch/backward-compatibility.sh $JBOSS_HOME/bin/launch
 cp -p ${ADDED_DIR}/launch/openshift-common.sh $JBOSS_HOME/bin/launch
 
 cp ${ADDED_DIR}/launch/management-realm.sh $JBOSS_HOME/bin/launch
+cp ${ADDED_DIR}/launch/jgroups.sh $JBOSS_HOME/bin/launch
 cp ${ADDED_DIR}/launch/cache-container.xml $JBOSS_HOME/bin/launch

--- a/tests/features/datagrid/7.1/datagrid.feature
+++ b/tests/features/datagrid/7.1/datagrid.feature
@@ -11,7 +11,7 @@ Feature: Openshift DataGrid tests
        | CONTAINER_SECURITY_ROLES                      | admin=ALL             |
        | DEFAULT_CACHE_SECURITY_AUTHORIZATION_ENABLED  | true                  |
        | DEFAULT_CACHE_SECURITY_AUTHORIZATION_ROLES    | admin                 |
-    Then container log should contain WFLYSRV0025: Data Grid 7.1.0
+    Then container log should contain WFLYSRV0025: Data Grid 7.1
     Then run /opt/datagrid/bin/readinessProbe.sh in container once
     Then run /opt/datagrid/bin/livenessProbe.sh in container once
 


### PR DESCRIPTION
The ENCRYPT protocol was deprecated and should not be used anymore.
JDG is using SYM_ENCRYPT since JDG 7.1.0.

Signed-off-by: Osni Oliveira <osni.oliveira@gmail.com>

Thanks for submitting your Pull Request!

Please make sure your PR meets following requirements:

- [x] Pull Request title is properly formatted: `[CLOUD-XYA] Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains description of the issue
- [x] Pull request does not include fixes for other issues than the main ticket
- [x] Attached commits represent unit of work and are properly formatted
- [x] You have read and agreed to the Developer Certificate of Origin (DCO) (see `CONTRIBUTING.md`)
- [x] Every commit contains `Signed-off-by: Your Name <yourname@redhat.com>` - use `git commit -s`

https://issues.jboss.org/browse/CLOUD-2226