### PR TITLE
[CLOUD-2316] only use JGroups ENCRYPT protocol with JDG 6.5

### DIFF
--- a/os-eap-launch/added/launch/jgroups.sh
+++ b/os-eap-launch/added/launch/jgroups.sh
@@ -18,46 +18,21 @@ function configureEnv() {
   configure
 }
 
-function version_compare() {
-  [ "$1" = "`echo -e \"$1\n$2\" | sort -V | head -n1`" ] && echo "older" || echo "newer"
-}
-
-function read_product_name() {
-  cat $JBOSS_HOME/version.txt | awk -F'- Version' '{ print $1 }' | xargs
-}
-
-function read_product_version() {
-  cat $JBOSS_HOME/version.txt | awk -F'- Version' '{ print $2 }' | xargs
-}
-
 function configure_jgroups_encryption() {
   jgroups_encrypt=""
 
   if [ -n "${JGROUPS_ENCRYPT_SECRET}" ]; then
     if [ -n "${JGROUPS_ENCRYPT_NAME}" -a -n "${JGROUPS_ENCRYPT_PASSWORD}" ] ; then
-      product=`read_product_name`
-      version=`read_product_version`
-
-      if [ "$product" == "Red Hat JBoss Enterprise Application Platform" -a "$(version_compare $version '6.4.4.GA')" == "newer" ]; then
-        # For new JGroups we need to use SYM_ENCRYPT protocol
-        jgroups_encrypt="\
-          <protocol type=\"SYM_ENCRYPT\">\
-            <property name=\"provider\">SunJCE</property>\
-            <property name=\"sym_algorithm\">AES</property>\
-            <property name=\"encrypt_entire_message\">true</property>\
-            <property name=\"keystore_name\">${JGROUPS_ENCRYPT_KEYSTORE_DIR}/${JGROUPS_ENCRYPT_KEYSTORE}</property>\
-            <property name=\"store_password\">${JGROUPS_ENCRYPT_PASSWORD}</property>\
-            <property name=\"alias\">${JGROUPS_ENCRYPT_NAME}</property>\
-          </protocol>"
-      else
-        # All other products use older JGroups ENCRYPT protocol
-        jgroups_encrypt="\
-          <protocol type=\"ENCRYPT\">\
-            <property name=\"key_store_name\">${JGROUPS_ENCRYPT_KEYSTORE_DIR}/${JGROUPS_ENCRYPT_KEYSTORE}</property>\
-            <property name=\"store_password\">${JGROUPS_ENCRYPT_PASSWORD}</property>\
-            <property name=\"alias\">${JGROUPS_ENCRYPT_NAME}</property>\
-          </protocol>"
-      fi
+      # For new JGroups we need to use SYM_ENCRYPT protocol
+      jgroups_encrypt="\
+        <protocol type=\"SYM_ENCRYPT\">\
+          <property name=\"provider\">SunJCE</property>\
+          <property name=\"sym_algorithm\">AES</property>\
+          <property name=\"encrypt_entire_message\">true</property>\
+          <property name=\"keystore_name\">${JGROUPS_ENCRYPT_KEYSTORE_DIR}/${JGROUPS_ENCRYPT_KEYSTORE}</property>\
+          <property name=\"store_password\">${JGROUPS_ENCRYPT_PASSWORD}</property>\
+          <property name=\"alias\">${JGROUPS_ENCRYPT_NAME}</property>\
+        </protocol>"
     else
       log_warning "Partial JGroups encryption configuration, the communication within the cluster WILL NOT be encrypted."
     fi

--- a/os-jdg-launch/added/launch/jgroups.sh
+++ b/os-jdg-launch/added/launch/jgroups.sh
@@ -1,5 +1,7 @@
 # only processes a single environment as the placeholder is not preserved
 
+source $JBOSS_HOME/bin/launch/logging.sh
+
 function prepareEnv() {
   unset JGROUPS_ENCRYPT_SECRET
   unset JGROUPS_ENCRYPT_PASSWORD
@@ -22,16 +24,13 @@ function configure_jgroups_encryption() {
   if [ -n "${JGROUPS_ENCRYPT_SECRET}" ]; then
     if [ -n "${JGROUPS_ENCRYPT_NAME}" -a -n "${JGROUPS_ENCRYPT_PASSWORD}" ] ; then
       jgroups_encrypt="\
-        <protocol type=\"SYM_ENCRYPT\">\
-          <property name=\"provider\">SunJCE</property>\
-          <property name=\"sym_algorithm\">AES</property>\
-          <property name=\"encrypt_entire_message\">true</property>\
-          <property name=\"keystore_name\">${JGROUPS_ENCRYPT_KEYSTORE_DIR}/${JGROUPS_ENCRYPT_KEYSTORE}</property>\
+        <protocol type=\"ENCRYPT\">\
+          <property name=\"key_store_name\">${JGROUPS_ENCRYPT_KEYSTORE_DIR}/${JGROUPS_ENCRYPT_KEYSTORE}</property>\
           <property name=\"store_password\">${JGROUPS_ENCRYPT_PASSWORD}</property>\
           <property name=\"alias\">${JGROUPS_ENCRYPT_NAME}</property>\
         </protocol>"
     else
-      echo "WARNING! Partial JGroups encryption configuration, the communication within the cluster WILL NOT be encrypted."
+      log_warning "Partial JGroups encryption configuration, the communication within the cluster WILL NOT be encrypted."
     fi
   fi
 

--- a/os-jdg-launch/configure.sh
+++ b/os-jdg-launch/configure.sh
@@ -19,3 +19,5 @@ cp -p ${ADDED_DIR}/launch/backward-compatibility.sh $JBOSS_HOME/bin/launch
 
 # Add common start script
 cp -p ${ADDED_DIR}/launch/openshift-common.sh $JBOSS_HOME/bin/launch
+
+cp ${ADDED_DIR}/launch/jgroups.sh $JBOSS_HOME/bin/launch

--- a/os-jdg7-launch/configure.sh
+++ b/os-jdg7-launch/configure.sh
@@ -21,5 +21,4 @@ cp -p ${ADDED_DIR}/launch/backward-compatibility.sh $JBOSS_HOME/bin/launch
 cp -p ${ADDED_DIR}/launch/openshift-common.sh $JBOSS_HOME/bin/launch
 
 cp ${ADDED_DIR}/launch/management-realm.sh $JBOSS_HOME/bin/launch
-cp ${ADDED_DIR}/launch/jgroups.sh $JBOSS_HOME/bin/launch
 cp ${ADDED_DIR}/launch/cache-container.xml $JBOSS_HOME/bin/launch


### PR DESCRIPTION
Cherrypick changes from https://github.com/jboss-openshift/cct_module/pull/198 also into the ```sprint-14``` branch.

Signed-off-by: rcernich <rcernich@redhat.com>
Signed-off-by: Jan Lieskovsky <jlieskov@redhat.com>

Thanks for submitting your Pull Request!

Please make sure your PR meets following requirements:

- [ ] Pull Request title is properly formatted: `[CLOUD-XYA] Subject`
- [ ] Pull Request contains link to the JIRA issue
- [ ] Pull Request contains description of the issue
- [ ] Pull request does not include fixes for other issues than the main ticket
- [ ] Attached commits represent unit of work and are properly formatted
- [ ] You have read and agreed to the Developer Certificate of Origin (DCO) (see `CONTRIBUTING.md`)
- [ ] Every commit contains `Signed-off-by: Your Name <yourname@redhat.com>` - use `git commit -s`
