### PR TITLE
[CLOUD-2379] Allow override LAUNCH_DIR

### DIFF
--- a/os-logging/configure.sh
+++ b/os-logging/configure.sh
@@ -12,8 +12,10 @@ else
   BIN_HOME="$JBOSS_HOME"
 fi
 
-mkdir -p ${BIN_HOME}/bin/launch
-cp -r ${ADDED_DIR}/launch/logging.sh ${BIN_HOME}/bin/launch
+LAUNCH_DIR=${LAUNCH_DIR:-$BIN_HOME/bin/launch}
 
-chown -R jboss:root ${BIN_HOME}/bin/launch/logging.sh
-chmod -R g+rwX ${BIN_HOME}/bin/launch/logging.sh
+mkdir -p ${LAUNCH_DIR}
+cp -r ${ADDED_DIR}/launch/logging.sh ${LAUNCH_DIR}
+
+chown -R jboss:root ${LAUNCH_DIR}/logging.sh
+chmod -R g+rwX ${LAUNCH_DIR}/logging.sh

--- a/os-logging/module.yaml
+++ b/os-logging/module.yaml
@@ -4,4 +4,3 @@ version: '1.0'
 description: os-logging script package.
 execute:
 - script: configure.sh
-  user: '185'


### PR DESCRIPTION
Part of the fix for https://issues.jboss.org/browse/RHBA-530
Fixes https://issues.jboss.org/browse/CLOUD-2379
Allows the possibility for non-eap images to decide where to copy the scripts