### PR TITLE
[CLOUD-2400] Changed logged error to a warning, because not having th…

### DIFF
--- a/os-datavirt/added/launch/teiid.sh
+++ b/os-datavirt/added/launch/teiid.sh
@@ -61,7 +61,7 @@ function update_users(){
     sed -i "s|##MODESHAPE_USERNAME##|${modeshapeuser}|" "${CONFIG_FILE}"
     sed -i "s|##MODESHAPE_PASSWORD##|${password}|" "${CONFIG_FILE}"
   else
-    log_error "No password was provided for '${modeshapeuser}' in the MODESHAPE_PASSWORD environment variable. JBoss Red Hat JBoss Data Virtualization will not work properly."
+    log_warning "No password was provided for '${modeshapeuser}' in the MODESHAPE_PASSWORD environment variable. Access to the ModeShape repository will not be available."
   fi
   
 }


### PR DESCRIPTION
[CLOUD-2400] Changed logged error to a warning, because not having the password doesn't impact the usage of JDV, only the access to the ModeShape repository

Signed-off-by: Van Halbert <vhalbert@redhat.com>

Thanks for submitting your Pull Request!

Please make sure your PR meets following requirements:

- [ ] Pull Request title is properly formatted: `[CLOUD-XYA] Subject`
- [ ] Pull Request contains link to the JIRA issue
- [ ] Pull Request contains description of the issue
- [ ] Pull request does not include fixes for other issues than the main ticket
- [ ] Attached commits represent unit of work and are properly formatted
- [ ] You have read and agreed to the Developer Certificate of Origin (DCO) (see `CONTRIBUTING.md`)
- [ ] Every commit contains `Signed-off-by: Your Name <yourname@redhat.com>` - use `git commit -s`
