### PR TITLE
WIP CLOUD-2461: move JAVA_* env vars into module(s) that uses them

### DIFF
--- a/os-java-run/module.yaml
+++ b/os-java-run/module.yaml
@@ -4,3 +4,10 @@ version: '1.0'
 description: Legacy os-java-run script package.
 execute:
 - script: install_as_root
+envs:
+    - name: JAVA_MAX_INITIAL_MEM
+      description: The maximum size of the initial heap memory, if the calculated default initial heap is larger then it will be capped at this value.  The default is 4096 MB.
+      example: "4096"
+    - name: JAVA_CORE_LIMIT
+      description: Core limit as described in https://www.kernel.org/doc/Documentation/scheduler/sched-bwc.txt.  Used to configure the number of GC threads and parallelism for ForkJoinPool.  Defaults to container core limit.
+      example: "2"


### PR DESCRIPTION
https://issues.jboss.org/browse/CLOUD-2461

moving some ENV var definitions to be located in the module that uses them

