### PR TITLE
[CLOUD-2465] Allow custom location for local maven repository

### DIFF
--- a/jboss-maven/added/jboss-settings.xml
+++ b/jboss-maven/added/jboss-settings.xml
@@ -3,6 +3,8 @@
           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
           xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 http://maven.apache.org/xsd/settings-1.0.0.xsd">
 
+    <!-- ### configured local repository ### -->
+
   <servers>
     <!-- ### configured servers ### -->
   </servers>

--- a/os-eap-launch/added/launch/maven-repos.sh
+++ b/os-eap-launch/added/launch/maven-repos.sh
@@ -7,6 +7,7 @@ function prepareEnv() {
     unset MAVEN_REPO_HOST
     unset MAVEN_REPO_ID
     unset MAVEN_REPO_LAYOUT
+    unset MAVEN_REPO_LOCAL
     unset MAVEN_REPO_PASSPHRASE
     unset MAVEN_REPO_PASSWORD
     unset MAVEN_REPO_PATH
@@ -32,6 +33,10 @@ function configure() {
 
 function configure_maven_repos {
     local settings="${1-$HOME/.m2/settings.xml}"
+    local local_repo_path="${MAVEN_REPO_LOCAL}"
+    if [ "${local_repo_path}" != "" ]; then
+        set_local_repo_path "${settings}" "${local_repo_path}"
+    fi
     # single repo scenario: respect fully qualified url if specified, otherwise find and use service
     local single_repo_url="${MAVEN_REPO_URL}"
     if [ "${single_repo_url}" = "" ]; then
@@ -177,3 +182,10 @@ function generate_random_id() {
     cat /dev/urandom | env LC_CTYPE=C tr -dc 'a-zA-Z0-9' | fold -w 16 | head -n 1
 }
 
+function set_local_repo_path() {
+    local settings="${1}"
+    local local_path="${2}"
+    local xml="\n\
+    <localRepository>${local_path}</localRepository>"
+    sed -i "s|<!-- ### configured local repository ### -->|${xml}|" "${settings}"    
+}

--- a/os-java-s2i/added/s2i/jboss-settings.xml
+++ b/os-java-s2i/added/s2i/jboss-settings.xml
@@ -3,6 +3,8 @@
           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
           xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 http://maven.apache.org/xsd/settings-1.0.0.xsd">
 
+    <!-- ### configured local repository ### -->
+
   <servers>
     <!-- ### configured servers ### -->
   </servers>

--- a/s2i-common/common.sh
+++ b/s2i-common/common.sh
@@ -169,3 +169,12 @@ clear_maven_repository() {
         rm -rf ${HOME}/.m2/repository/*
     fi
 }
+
+# set local repository path for maven to the provided path
+function set_local_repo_path() {
+    local settings="${1}"
+    local local_path="${2}"
+    local xml="\n\
+    <localRepository>${local_path}</localRepository>"
+    sed -i "s|<!-- ### configured local repository ### -->|${xml}|" "${settings}"    
+}


### PR DESCRIPTION
https://issues.jboss.org/browse/CLOUD-2465
Allow custom location for local maven repository by using <localRepository> to designate a location other than the standard ~/.m2/repository

Thanks for submitting your Pull Request!

Please make sure your PR meets following requirements:

- [ ] Pull Request title is properly formatted: `[CLOUD-XYA] Subject`
- [ ] Pull Request contains link to the JIRA issue
- [ ] Pull Request contains description of the issue
- [ ] Pull request does not include fixes for other issues than the main ticket
- [ ] Attached commits represent unit of work and are properly formatted
- [ ] You have read and agreed to the Developer Certificate of Origin (DCO) (see `CONTRIBUTING.md`)
- [ ] Every commit contains `Signed-off-by: Your Name <yourname@redhat.com>` - use `git commit -s`
