### PR TITLE
CLOUD-2501 - java.io.IOException: Invalid secret key format on JCEKS keystores

### DIFF
--- a/os-eap64-launch/added/launch/jboss_modules_system_pkgs.sh
+++ b/os-eap64-launch/added/launch/jboss_modules_system_pkgs.sh
@@ -8,7 +8,7 @@ function configure() {
 }
 
 function configure_jboss_modules_system_pkgs() {
-  JBOSS_MODULES_SYSTEM_PKGS="org.jboss.logmanager,jdk.nashorn.api"
+  JBOSS_MODULES_SYSTEM_PKGS="org.jboss.logmanager,jdk.nashorn.api,com.sun.crypto.provider"
 
   if [ -n "$JBOSS_MODULES_SYSTEM_PKGS_APPEND" ]; then
     JBOSS_MODULES_SYSTEM_PKGS="$JBOSS_MODULES_SYSTEM_PKGS,$JBOSS_MODULES_SYSTEM_PKGS_APPEND"

--- a/os-eap7-launch/added/launch/jboss_modules_system_pkgs.sh
+++ b/os-eap7-launch/added/launch/jboss_modules_system_pkgs.sh
@@ -8,7 +8,7 @@ function configure() {
 }
 
 function configure_jboss_modules_system_pkgs() {
-  JBOSS_MODULES_SYSTEM_PKGS="org.jboss.logmanager,jdk.nashorn.api"
+  JBOSS_MODULES_SYSTEM_PKGS="org.jboss.logmanager,jdk.nashorn.api,com.sun.crypto.provider"
 
   if [ -n "$JBOSS_MODULES_SYSTEM_PKGS_APPEND" ]; then
     JBOSS_MODULES_SYSTEM_PKGS="$JBOSS_MODULES_SYSTEM_PKGS,$JBOSS_MODULES_SYSTEM_PKGS_APPEND"


### PR DESCRIPTION
This adds com.sun.crypto.provider to JBOSS_MODULES_SYSTEM_PKGS for both EAP 7 and EAP 6.4.

https://issues.jboss.org/browse/CLOUD-2501