### PR TITLE
[CLOUD-2501] Add modules system pkgs script to JDG 7.x - sprint-15

### DIFF
--- a/os-jdg7-launch/added/launch/openshift-common.sh
+++ b/os-jdg7-launch/added/launch/openshift-common.sh
@@ -20,6 +20,7 @@ CONFIGURE_SCRIPTS=(
   $JBOSS_HOME/bin/launch/https.sh
   $JBOSS_HOME/bin/launch/json_logging.sh
   $JBOSS_HOME/bin/launch/security-domains.sh
+  $JBOSS_HOME/bin/launch/jboss_modules_system_pkgs.sh
   $JBOSS_HOME/bin/launch/infinispan-config.sh
   $JBOSS_HOME/bin/launch/management-realm.sh
   $JBOSS_HOME/bin/launch/access_log_valve.sh


### PR DESCRIPTION
Enables JDG 7.x to use the fix for [CLOUD-2501](https://issues.jboss.org/browse/CLOUD-2501).
See #238.

Thanks for submitting your Pull Request!

Please make sure your PR meets following requirements:

- [X] Pull Request title is properly formatted: `[CLOUD-XYA] Subject`
- [X] Pull Request contains link to the JIRA issue
- [X] Pull Request contains description of the issue
- [X] Pull request does not include fixes for other issues than the main ticket
- [X] Attached commits represent unit of work and are properly formatted
- [X] You have read and agreed to the Developer Certificate of Origin (DCO) (see `CONTRIBUTING.md`)
- [X] Every commit contains `Signed-off-by: Your Name <yourname@redhat.com>` - use `git commit -s`
