### PR TITLE
[CLOUD-2509] Broken link to rh mvn repository

### DIFF
--- a/os-java-jolokia/module.yaml
+++ b/os-java-jolokia/module.yaml
@@ -55,6 +55,5 @@ execute:
 - script: install_as_root
 
 artifacts:
-#- name: jolokia-jvm-agent.jar
-- url: https://maven.repository.redhat.com/ga/org/jolokia/jolokia-jvm/1.5.0.redhat-1/jolokia-jvm-1.5.0.redhat-1-agent.jar
+- name: jolokia-jvm-1.5.0.redhat-1-agent.jar
   md5: d31c6b1525e6d2d24062ef26a9f639a8


### PR DESCRIPTION
The link to https://maven.repository.redhat.com/ga/org/jolokia/jolokia-jvm/1.5.0.redhat-1/jolokia-jvm-1.5.0.redhat-1-agent.jar is broken which is making the builds to fail. However, the artifact exists in the local cache.

https://issues.jboss.org/browse/CLOUD-2509

Signed-off-by: Ruben Romero Montes <rromerom@redhat.com>

- [x] Pull Request title is properly formatted: `[CLOUD-XYA] Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains description of the issue
- [x] Pull request does not include fixes for other issues than the main ticket
- [x] Attached commits represent unit of work and are properly formatted
- [x] You have read and agreed to the Developer Certificate of Origin (DCO) (see `CONTRIBUTING.md`)
- [x] Every commit contains `Signed-off-by: Your Name <yourname@redhat.com>` - use `git commit -s`
