### PR TITLE
CLOUD-2511 - cct_module test fixes

### DIFF
--- a/tests/features/eap/6.4/eap.feature
+++ b/tests/features/eap/6.4/eap.feature
@@ -13,7 +13,7 @@ Feature: Openshift EAP basic tests
 
   Scenario: Check that the labels are correctly set
     Given image is built
-     Then the image should contain label com.redhat.component with value jboss-eap-6-eap64-openshift-docker
+     Then the image should contain label com.redhat.component with value jboss-eap-6-eap64-openshift-container
       And the image should contain label name with value jboss-eap-6/eap64-openshift
       And the image should contain label io.openshift.expose-services with value 8080:http
       And the image should contain label io.openshift.tags with value builder,javaee,eap,eap6

--- a/tests/features/eap/7.1/eap_7_1.feature
+++ b/tests/features/eap/7.1/eap_7_1.feature
@@ -8,7 +8,7 @@ Feature: Openshift EAP 7.1 basic tests
 
   Scenario: Check that the labels are correctly set
     Given image is built
-    Then the image should contain label com.redhat.component with value jboss-eap-7-eap71-openshift-docker
+    Then the image should contain label com.redhat.component with value jboss-eap-7-eap71-openshift-container
      And the image should contain label name with value jboss-eap-7/eap71-openshift
      And the image should contain label io.openshift.expose-services with value 8080:http
      And the image should contain label io.openshift.tags with value builder,javaee,eap,eap7

--- a/tests/features/eap/eap_common.feature
+++ b/tests/features/eap/eap_common.feature
@@ -128,7 +128,7 @@ Feature: Openshift EAP common tests (EAP and EAP derived images)
   Scenario: jboss.modules.system.pkgs is set to defaults when JBOSS_MODULES_SYSTEM_PKGS_APPEND env var is not set
     When container is ready
     Then container log should contain VM Arguments:
-     And available container log should contain -Djboss.modules.system.pkgs=org.jboss.logmanager,jdk.nashorn.api
+     And available container log should contain -Djboss.modules.system.pkgs=org.jboss.logmanager,jdk.nashorn.api,com.sun.crypto.provider
 
   @jboss-eap-7 @jboss-eap-6/eap64-openshift
   Scenario: jboss.modules.system.pkgs will contain default value and the value of JBOSS_MODULES_SYSTEM_PKGS_APPEND env var, when it is set
@@ -136,7 +136,7 @@ Feature: Openshift EAP common tests (EAP and EAP derived images)
       | variable                             | value           |
       | JBOSS_MODULES_SYSTEM_PKGS_APPEND     | org.foo.bar     |
     Then container log should contain VM Arguments:
-     And available container log should contain -Djboss.modules.system.pkgs=org.jboss.logmanager,jdk.nashorn.api,org.foo.bar
+     And available container log should contain -Djboss.modules.system.pkgs=org.jboss.logmanager,jdk.nashorn.api,com.sun.crypto.provider,org.foo.bar
 
   @jboss-eap-7 @jboss-eap-6/eap64-openshift @redhat-sso-7 @jboss-datavirt-6
   Scenario: check ownership when started as alternative UID


### PR DESCRIPTION
This addresses the EAP 6.4 and 7.1 breakage in the behave tests due to the changes in CLOUD-2501. It also updates the -docker suffix to -container. (Also, not that this is included in the list of things to revert when we drop the CLOUD-2501 workarounds in CLOUD-2506 & CLOUD-2507.)

There may be additional testing issues, I'll open up seperate tickets to address those and add support for testing EAP-CD (which I have almost completed).

https://issues.jboss.org/browse/CLOUD-2511
Signed-off-by: Ken Wills <kwills@redhat.com>

Thanks for submitting your Pull Request!
Please make sure your PR meets following requirements:

- [x] Pull Request title is properly formatted: `[CLOUD-XYA] Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains description of the issue
- [x] Pull request does not include fixes for other issues than the main ticket
- [x] Attached commits represent unit of work and are properly formatted
- [x] You have read and agreed to the Developer Certificate of Origin (DCO) (see `CONTRIBUTING.md`)
- [x] Every commit contains `Signed-off-by: Your Name <yourname@redhat.com>` - use `git commit -s`
