### PR TITLE
[CLOUD-2514] Make description of JAVA_MAX_MEM_RATIO environment variable container runtime-agnostic. Same for README.adoc

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1,3 +1,3 @@
 = Cloud Enablement CCT module
 
-This repository serves as a temporary public link:https://github.com/concrt/concreate[Concreate] module for building JBoss Openshift Docker images. This repository is an enhanced copy of shell scripts used to build JBoss images for OpenShift.
+This repository serves as a temporary public link:https://github.com/concrt/concreate[Concreate] module for building JBoss Openshift container images. This repository is an enhanced copy of shell scripts used to build JBoss images for OpenShift.

--- a/datagrid-openshift/module.yaml
+++ b/datagrid-openshift/module.yaml
@@ -5,3 +5,7 @@ description: Legacy datagrid-openshift script package.
 execute:
 - script: configure.sh
   user: '185'
+envs:
+    - name: GC_MAX_METASPACE_SIZE
+      description: The maximum metaspace size.
+      example: "256"

--- a/datagrid-openshift/module.yaml
+++ b/datagrid-openshift/module.yaml
@@ -2,13 +2,9 @@ schema_version: 1
 name: datagrid-openshift
 version: '1.0'
 description: Legacy datagrid-openshift script package.
+modules:
+  install:
+  - name: os-java-run
 execute:
 - script: configure.sh
   user: '185'
-envs:
-    - name: GC_MAX_METASPACE_SIZE
-      description: The maximum metaspace size.
-      example: "256"
-    - name: "JAVA_OPTS_APPEND"
-      example: "-Dfoo=bar"
-      description: "Server startup options."

--- a/datagrid-openshift/module.yaml
+++ b/datagrid-openshift/module.yaml
@@ -9,3 +9,6 @@ envs:
     - name: GC_MAX_METASPACE_SIZE
       description: The maximum metaspace size.
       example: "256"
+    - name: "JAVA_OPTS_APPEND"
+      example: "-Dfoo=bar"
+      description: "Server startup options."

--- a/dynamic-resources/module.yaml
+++ b/dynamic-resources/module.yaml
@@ -2,6 +2,9 @@ schema_version: 1
 name: dynamic-resources
 version: '1.0'
 description: Legacy dynamic-resources script package.
+modules:
+  install:
+  - name: os-java-run
 execute:
 - script: install.sh
 envs:
@@ -11,9 +14,3 @@ envs:
     - name: "CONTAINER_HEAP_PERCENT"
       example: 0.5
       description: Deprecated. See JAVA_MAX_MEM_RATIO.
-    - name: JAVA_MAX_MEM_RATIO
-      description: This is used to calculate a default maximal heap memory based on a containers restriction. If used in a container without any memory constraints for the container then this option has no effect. If there is a memory constraint then `-Xmx` is set to a ratio of the container available memory as set here. The default is `50` which means 50% of the available memory is used as an upper boundary. You can skip this mechanism by setting this value to `0` in which case no `-Xmx` option is added.
-      example: "50"
-    - name: JAVA_INITIAL_MEM_RATIO
-      description: This is used to calculate a default initial heap memory based the maximumal heap memory. The default is `100` which means 100% of the maximal heap is used for the initial heap size. You can skip this mechanism by setting this value to `0` in which case no `-Xms` option is added.
-      example: "100"

--- a/dynamic-resources/module.yaml
+++ b/dynamic-resources/module.yaml
@@ -4,3 +4,7 @@ version: '1.0'
 description: Legacy dynamic-resources script package.
 execute:
 - script: install.sh
+envs:
+    - name: "CONTAINER_HEAP_PERCENT"
+      example: 0.5
+      description: Deprecated.  See JAVA_MAX_MEM_RATIO.

--- a/dynamic-resources/module.yaml
+++ b/dynamic-resources/module.yaml
@@ -7,14 +7,13 @@ execute:
 envs:
     - name: "INITIAL_HEAP_PERCENT"
       example: 0.5
-      description: Deprecated.  See JAVA_INITIAL_MEM_RATIO.
+      description: Deprecated. See JAVA_INITIAL_MEM_RATIO.
     - name: "CONTAINER_HEAP_PERCENT"
       example: 0.5
-      description: Deprecated.  See JAVA_MAX_MEM_RATIO.
+      description: Deprecated. See JAVA_MAX_MEM_RATIO.
     - name: JAVA_MAX_MEM_RATIO
-      description: This is used to calculate a default maximal heap memory based on a containers restriction. If used in a Docker container without any memory constraints for the container then this option has no effect. If there is a memory constraint then `-Xmx` is set to a ratio of the container available memory as set here. The default is `50` which means 50% of the available memory is used as an upper boundary. You can skip this mechanism by setting this value to `0` in which case no `-Xmx` option
-            is added.
+      description: This is used to calculate a default maximal heap memory based on a containers restriction. If used in a container without any memory constraints for the container then this option has no effect. If there is a memory constraint then `-Xmx` is set to a ratio of the container available memory as set here. The default is `50` which means 50% of the available memory is used as an upper boundary. You can skip this mechanism by setting this value to `0` in which case no `-Xmx` option is added.
       example: "50"
     - name: JAVA_INITIAL_MEM_RATIO
-      description: This is used to calculate a default initial heap memory based the maximumal heap memory.  The default is `100` which means 100% of the maximal heap is used for the initial heap size.  You can skip this mechanism by setting this value to `0` in which case no `-Xms` option is added.
+      description: This is used to calculate a default initial heap memory based the maximumal heap memory. The default is `100` which means 100% of the maximal heap is used for the initial heap size. You can skip this mechanism by setting this value to `0` in which case no `-Xms` option is added.
       example: "100"

--- a/dynamic-resources/module.yaml
+++ b/dynamic-resources/module.yaml
@@ -5,6 +5,9 @@ description: Legacy dynamic-resources script package.
 execute:
 - script: install.sh
 envs:
+    - name: "INITIAL_HEAP_PERCENT"
+      example: 0.5
+      description: Deprecated.  See JAVA_INITIAL_MEM_RATIO.
     - name: "CONTAINER_HEAP_PERCENT"
       example: 0.5
       description: Deprecated.  See JAVA_MAX_MEM_RATIO.

--- a/dynamic-resources/module.yaml
+++ b/dynamic-resources/module.yaml
@@ -8,3 +8,10 @@ envs:
     - name: "CONTAINER_HEAP_PERCENT"
       example: 0.5
       description: Deprecated.  See JAVA_MAX_MEM_RATIO.
+    - name: JAVA_MAX_MEM_RATIO
+      description: This is used to calculate a default maximal heap memory based on a containers restriction. If used in a Docker container without any memory constraints for the container then this option has no effect. If there is a memory constraint then `-Xmx` is set to a ratio of the container available memory as set here. The default is `50` which means 50% of the available memory is used as an upper boundary. You can skip this mechanism by setting this value to `0` in which case no `-Xmx` option
+            is added.
+      example: "50"
+    - name: JAVA_INITIAL_MEM_RATIO
+      description: This is used to calculate a default initial heap memory based the maximumal heap memory.  The default is `100` which means 100% of the maximal heap is used for the initial heap size.  You can skip this mechanism by setting this value to `0` in which case no `-Xms` option is added.
+      example: "100"

--- a/os-amq-launch/module.yaml
+++ b/os-amq-launch/module.yaml
@@ -2,14 +2,12 @@ schema_version: 1
 name: os-amq-launch
 version: '1.0'
 description: Legacy os-amq-launch script package.
+modules:
+  install:
+  - name: os-java-run
 execute:
 - script: install.sh
 
 artifacts:
 - path: ce-amq-drain-1.0.0.Final-redhat-1.jar
   md5: 65b9aba8e5a0b7d7b259a6028f85595e
-
-envs:
-    - name: "JAVA_OPTS_APPEND"
-      example: "-Dfoo=bar"
-      description: "Server startup options."

--- a/os-amq-launch/module.yaml
+++ b/os-amq-launch/module.yaml
@@ -8,3 +8,8 @@ execute:
 artifacts:
 - path: ce-amq-drain-1.0.0.Final-redhat-1.jar
   md5: 65b9aba8e5a0b7d7b259a6028f85595e
+
+envs:
+    - name: "JAVA_OPTS_APPEND"
+      example: "-Dfoo=bar"
+      description: "Server startup options."

--- a/os-datavirt-s2i/module.yaml
+++ b/os-datavirt-s2i/module.yaml
@@ -2,9 +2,8 @@ schema_version: 1
 name: os-datavirt-s2i
 version: '1.0'
 description: Legacy os-datavirt-s2i script package.
+modules:
+  install:
+  - name: os-eap-s2i
 execute:
 - script: prepare.sh
-envs:
-- name: CUSTOM_INSTALL_DIRECTORIES
-  description: A list of comma-separated directories used for installation and configuration of artifacts for the image during the S2I process.
-  example: "custom,shared"

--- a/os-datavirt-s2i/module.yaml
+++ b/os-datavirt-s2i/module.yaml
@@ -4,3 +4,7 @@ version: '1.0'
 description: Legacy os-datavirt-s2i script package.
 execute:
 - script: prepare.sh
+envs:
+- name: CUSTOM_INSTALL_DIRECTORIES
+  description: A list of comma-separated directories used for installation and configuration of artifacts for the image during the S2I process.
+  example: "custom,shared"

--- a/os-datavirt/module.yaml
+++ b/os-datavirt/module.yaml
@@ -16,3 +16,8 @@ packages:
           - jboss-os
       install:
           - hostname
+
+run:
+      user: 185
+      cmd:
+          - "/opt/eap/bin/openshift-launch.sh"

--- a/os-datavirt/module.yaml
+++ b/os-datavirt/module.yaml
@@ -10,3 +10,9 @@ modules:
 execute:
 - script: configure.sh
   user: '185'
+
+packages:
+      repositories:
+          - jboss-os
+      install:
+          - hostname

--- a/os-datavirt/module.yaml
+++ b/os-datavirt/module.yaml
@@ -11,12 +11,6 @@ execute:
 - script: configure.sh
   user: '185'
 
-packages:
-      repositories:
-          - jboss-os
-      install:
-          - hostname
-
 run:
       user: 185
       cmd:

--- a/os-datavirt/module.yaml
+++ b/os-datavirt/module.yaml
@@ -5,6 +5,7 @@ description: Legacy os-datavirt script package.
 
 modules:
   install:
+  - name: os-eap-launch
   - name: os-eap-migration
 
 execute:

--- a/os-eap-db-drivers/module.yaml
+++ b/os-eap-db-drivers/module.yaml
@@ -5,3 +5,11 @@ description: Legacy os-eap-db-drivers script package.
 execute:
 - script: configure.sh
   user: '185'
+packages:
+      repositories:
+          - jboss-os
+          - jboss-rhscl
+      install:
+          - rh-mongodb32-mongo-java-driver
+          - postgresql-jdbc
+          - mysql-connector-java

--- a/os-eap-launch/module.yaml
+++ b/os-eap-launch/module.yaml
@@ -10,3 +10,6 @@ packages:
           - jboss-os
       install:
           - hostname
+envs:
+    - name: "DEFAULT_ADMIN_USERNAME"
+      value: "eapadmin"

--- a/os-eap-launch/module.yaml
+++ b/os-eap-launch/module.yaml
@@ -13,3 +13,6 @@ packages:
 envs:
     - name: "DEFAULT_ADMIN_USERNAME"
       value: "eapadmin"
+    - name: "ENABLE_ACCESS_LOG"
+      example: "true"
+      description: Enable the Access Log.

--- a/os-eap-launch/module.yaml
+++ b/os-eap-launch/module.yaml
@@ -5,3 +5,8 @@ description: Legacy os-eap-launch script package.
 execute:
 - script: configure.sh
   user: '185'
+packages:
+      repositories:
+          - jboss-os
+      install:
+          - hostname

--- a/os-eap-probes/module.yaml
+++ b/os-eap-probes/module.yaml
@@ -5,3 +5,9 @@ description: Legacy os-eap-probes script package.
 execute:
 - script: configure.sh
   user: '185'
+packages:
+      repositories:
+          - jboss-os
+      install:
+          - python-enum34
+          - python-requests

--- a/os-eap-probes/module.yaml
+++ b/os-eap-probes/module.yaml
@@ -11,3 +11,7 @@ packages:
       install:
           - python-enum34
           - python-requests
+envs:
+    - name: "PROBE_DISABLE_BOOT_ERRORS_CHECK"
+      example: "true"
+      description: Disable the boot errors check in the probes.

--- a/os-eap-s2i/module.yaml
+++ b/os-eap-s2i/module.yaml
@@ -4,3 +4,7 @@ version: '1.0'
 description: Legacy os-eap-s2i script package.
 execute:
 - script: prepare.sh
+envs:
+- name: CUSTOM_INSTALL_DIRECTORIES
+  description: A list of comma-separated directories used for installation and configuration of artifacts for the image during the S2I process.
+  example: "custom,shared"

--- a/os-eap-sso/module.yaml
+++ b/os-eap-sso/module.yaml
@@ -5,8 +5,3 @@ description: Legacy os-eap-sso script package.
 execute:
 - script: configure.sh
   user: '185'
-packages:
-      repositories:
-          - jboss-os
-      install:
-          - hostname

--- a/os-eap-sso/module.yaml
+++ b/os-eap-sso/module.yaml
@@ -5,3 +5,6 @@ description: Legacy os-eap-sso script package.
 execute:
 - script: configure.sh
   user: '185'
+modules:
+  install:
+  - name: os-eap-launch

--- a/os-eap-sso/module.yaml
+++ b/os-eap-sso/module.yaml
@@ -5,3 +5,8 @@ description: Legacy os-eap-sso script package.
 execute:
 - script: configure.sh
   user: '185'
+packages:
+      repositories:
+          - jboss-os
+      install:
+          - hostname

--- a/os-eap64-launch/module.yaml
+++ b/os-eap64-launch/module.yaml
@@ -20,6 +20,9 @@ envs:
       description: "Comma-separated list of package names that will be appended to the JBOSS_MODULES_SYSTEM_PKGS environment variable."
     - name: "JBOSS_MODULES_SYSTEM_PKGS"
       value: "org.jboss.logmanager,jdk.nashorn.api"
+    - name: "ENABLE_JSON_LOGGING"
+      example: "true"
+      description: Enable JSON-formatted logging
 
 packages:
       repositories:

--- a/os-eap64-launch/module.yaml
+++ b/os-eap64-launch/module.yaml
@@ -5,6 +5,7 @@ description: Legacy os-eap64-launch script package.
 
 modules:
   install:
+  - name: os-eap-launch
   - name: os-eap-node-name
   - name: os-eap-migration
 

--- a/os-eap64-launch/module.yaml
+++ b/os-eap64-launch/module.yaml
@@ -15,3 +15,9 @@ envs:
     - name: "MQ_SIMPLE_DEFAULT_PHYSICAL_DESTINATION"
       example: "false"
       description: "For backwards compatability, set to true to use 'MyQueue' and 'MyTopic' as physical destination name defaults instead of 'queue/MyQueue' and 'topic/MyTopic'."
+
+packages:
+      repositories:
+          - jboss-os
+      install:
+          - hostname

--- a/os-eap64-launch/module.yaml
+++ b/os-eap64-launch/module.yaml
@@ -18,6 +18,8 @@ envs:
     - name: "JBOSS_MODULES_SYSTEM_PKGS_APPEND"
       example: "org.jboss.byteman"
       description: "Comma-separated list of package names that will be appended to the JBOSS_MODULES_SYSTEM_PKGS environment variable."
+    - name: "JBOSS_MODULES_SYSTEM_PKGS"
+      value: "org.jboss.logmanager,jdk.nashorn.api"
 
 packages:
       repositories:

--- a/os-eap64-launch/module.yaml
+++ b/os-eap64-launch/module.yaml
@@ -15,6 +15,9 @@ envs:
     - name: "MQ_SIMPLE_DEFAULT_PHYSICAL_DESTINATION"
       example: "false"
       description: "For backwards compatability, set to true to use 'MyQueue' and 'MyTopic' as physical destination name defaults instead of 'queue/MyQueue' and 'topic/MyTopic'."
+    - name: "JBOSS_MODULES_SYSTEM_PKGS_APPEND"
+      example: "org.jboss.byteman"
+      description: "Comma-separated list of package names that will be appended to the JBOSS_MODULES_SYSTEM_PKGS environment variable."
 
 packages:
       repositories:

--- a/os-eap64-launch/module.yaml
+++ b/os-eap64-launch/module.yaml
@@ -24,12 +24,6 @@ envs:
       example: "true"
       description: Enable JSON-formatted logging
 
-packages:
-      repositories:
-          - jboss-os
-      install:
-          - hostname
-
 run:
       user: 185
       cmd:

--- a/os-eap64-launch/module.yaml
+++ b/os-eap64-launch/module.yaml
@@ -21,3 +21,8 @@ packages:
           - jboss-os
       install:
           - hostname
+
+run:
+      user: 185
+      cmd:
+          - "/opt/eap/bin/openshift-launch.sh"

--- a/os-eap64-launch/module.yaml
+++ b/os-eap64-launch/module.yaml
@@ -11,3 +11,7 @@ modules:
 execute:
 - script: configure.sh
   user: '185'
+envs:
+    - name: "MQ_SIMPLE_DEFAULT_PHYSICAL_DESTINATION"
+      example: "false"
+      description: "For backwards compatability, set to true to use 'MyQueue' and 'MyTopic' as physical destination name defaults instead of 'queue/MyQueue' and 'topic/MyTopic'."

--- a/os-eap64-openshift/module.yaml
+++ b/os-eap64-openshift/module.yaml
@@ -10,3 +10,6 @@ envs:
     - name: GC_MAX_METASPACE_SIZE
       description: The maximum metaspace size.
       example: "256"
+    - name: "JAVA_OPTS_APPEND"
+      example: "-Dfoo=bar"
+      description: "Server startup options."

--- a/os-eap64-openshift/module.yaml
+++ b/os-eap64-openshift/module.yaml
@@ -6,3 +6,7 @@ execute:
 - script: prepare.sh
 - script: configure.sh
   user: '185'
+envs:
+    - name: GC_MAX_METASPACE_SIZE
+      description: The maximum metaspace size.
+      example: "256"

--- a/os-eap64-openshift/module.yaml
+++ b/os-eap64-openshift/module.yaml
@@ -2,14 +2,10 @@ schema_version: 1
 name: os-eap64-openshift
 version: '1.0'
 description: Legacy os-eap64-openshift script package.
+modules:
+  install:
+  - name: os-java-run
 execute:
 - script: prepare.sh
 - script: configure.sh
   user: '185'
-envs:
-    - name: GC_MAX_METASPACE_SIZE
-      description: The maximum metaspace size.
-      example: "256"
-    - name: "JAVA_OPTS_APPEND"
-      example: "-Dfoo=bar"
-      description: "Server startup options."

--- a/os-eap7-launch/module.yaml
+++ b/os-eap7-launch/module.yaml
@@ -5,6 +5,7 @@ description: Legacy os-eap7-launch script package.
 
 modules:
   install:
+  - name: os-eap-launch
   - name: os-eap-node-name
   - name: os-eap-migration
 

--- a/os-eap7-launch/module.yaml
+++ b/os-eap7-launch/module.yaml
@@ -29,9 +29,3 @@ envs:
     - name: "ENABLE_JSON_LOGGING"
       example: "true"
       description: Enable JSON-formatted logging
-
-packages:
-      repositories:
-          - jboss-os
-      install:
-          - hostname

--- a/os-eap7-launch/module.yaml
+++ b/os-eap7-launch/module.yaml
@@ -20,6 +20,9 @@ envs:
       description: "Comma-separated list of package names that will be appended to the JBOSS_MODULES_SYSTEM_PKGS environment variable."
     - name: "JBOSS_MODULES_SYSTEM_PKGS"
       value: "org.jboss.logmanager,jdk.nashorn.api"
+    - name: "DEFAULT_JMS_CONNECTION_FACTORY"
+      example: "java:jboss/DefaultJMSConnectionFactory"
+      description: "Specify the default JNDI binding for the JMS connection factory (jms-connection-factory='java:jboss/DefaultJMSConnectionFactory')."
 
 packages:
       repositories:

--- a/os-eap7-launch/module.yaml
+++ b/os-eap7-launch/module.yaml
@@ -18,6 +18,8 @@ envs:
     - name: "JBOSS_MODULES_SYSTEM_PKGS_APPEND"
       example: "org.jboss.byteman"
       description: "Comma-separated list of package names that will be appended to the JBOSS_MODULES_SYSTEM_PKGS environment variable."
+    - name: "JBOSS_MODULES_SYSTEM_PKGS"
+      value: "org.jboss.logmanager,jdk.nashorn.api"
 
 packages:
       repositories:

--- a/os-eap7-launch/module.yaml
+++ b/os-eap7-launch/module.yaml
@@ -15,6 +15,9 @@ envs:
     - name: "MQ_SIMPLE_DEFAULT_PHYSICAL_DESTINATION"
       example: "false"
       description: "For backwards compatability, set to true to use 'MyQueue' and 'MyTopic' as physical destination name defaults instead of 'queue/MyQueue' and 'topic/MyTopic'."
+    - name: "JBOSS_MODULES_SYSTEM_PKGS_APPEND"
+      example: "org.jboss.byteman"
+      description: "Comma-separated list of package names that will be appended to the JBOSS_MODULES_SYSTEM_PKGS environment variable."
 
 packages:
       repositories:

--- a/os-eap7-launch/module.yaml
+++ b/os-eap7-launch/module.yaml
@@ -26,6 +26,9 @@ envs:
     - name: "CLI_GRACEFUL_SHUTDOWN"
       example: "true"
       description: "If set to any non zero length value then the image will prevent shutdown with the TERM signal and will require execution of the shutdown command through jboss-cli."
+    - name: "ENABLE_JSON_LOGGING"
+      example: "true"
+      description: Enable JSON-formatted logging
 
 packages:
       repositories:

--- a/os-eap7-launch/module.yaml
+++ b/os-eap7-launch/module.yaml
@@ -11,3 +11,8 @@ modules:
 execute:
 - script: configure.sh
   user: '185'
+envs:
+    - name: "MQ_SIMPLE_DEFAULT_PHYSICAL_DESTINATION"
+      example: "false"
+      description: "For backwards compatability, set to true to use 'MyQueue' and 'MyTopic' as physical destination name defaults instead of 'queue/MyQueue' and 'topic/MyTopic'."
+

--- a/os-eap7-launch/module.yaml
+++ b/os-eap7-launch/module.yaml
@@ -16,3 +16,8 @@ envs:
       example: "false"
       description: "For backwards compatability, set to true to use 'MyQueue' and 'MyTopic' as physical destination name defaults instead of 'queue/MyQueue' and 'topic/MyTopic'."
 
+packages:
+      repositories:
+          - jboss-os
+      install:
+          - hostname

--- a/os-eap7-launch/module.yaml
+++ b/os-eap7-launch/module.yaml
@@ -23,6 +23,9 @@ envs:
     - name: "DEFAULT_JMS_CONNECTION_FACTORY"
       example: "java:jboss/DefaultJMSConnectionFactory"
       description: "Specify the default JNDI binding for the JMS connection factory (jms-connection-factory='java:jboss/DefaultJMSConnectionFactory')."
+    - name: "CLI_GRACEFUL_SHUTDOWN"
+      example: "true"
+      description: "If set to any non zero length value then the image will prevent shutdown with the TERM signal and will require execution of the shutdown command through jboss-cli."
 
 packages:
       repositories:

--- a/os-eap7-openshift/module.yaml
+++ b/os-eap7-openshift/module.yaml
@@ -10,3 +10,6 @@ envs:
     - name: GC_MAX_METASPACE_SIZE
       description: The maximum metaspace size.
       example: "256"
+    - name: "JAVA_OPTS_APPEND"
+      example: "-Dfoo=bar"
+      description: "Server startup options."

--- a/os-eap7-openshift/module.yaml
+++ b/os-eap7-openshift/module.yaml
@@ -6,3 +6,7 @@ execute:
 - script: prepare.sh
 - script: configure.sh
   user: '185'
+envs:
+    - name: GC_MAX_METASPACE_SIZE
+      description: The maximum metaspace size.
+      example: "256"

--- a/os-eap7-openshift/module.yaml
+++ b/os-eap7-openshift/module.yaml
@@ -2,14 +2,10 @@ schema_version: 1
 name: os-eap7-openshift
 version: '1.0'
 description: Legacy os-eap7-openshift script package.
+modules:
+  install:
+  - name: os-java-run
 execute:
 - script: prepare.sh
 - script: configure.sh
   user: '185'
-envs:
-    - name: GC_MAX_METASPACE_SIZE
-      description: The maximum metaspace size.
-      example: "256"
-    - name: "JAVA_OPTS_APPEND"
-      example: "-Dfoo=bar"
-      description: "Server startup options."

--- a/os-java-run/module.yaml
+++ b/os-java-run/module.yaml
@@ -4,3 +4,10 @@ version: '1.0'
 description: Legacy os-java-run script package.
 execute:
 - script: install_as_root
+envs:
+    - name: JAVA_MAX_INITIAL_MEM
+      description: The maximum size of the initial heap memory, if the calculated default initial heap is larger then it will be capped at this value.  The default is 4096 MB.
+      example: "4096"
+    - name: JAVA_CORE_LIMIT
+      description: Core limit as described in https://www.kernel.org/doc/Documentation/scheduler/sched-bwc.txt.  Used to configure the number of GC threads and parallelism for ForkJoinPool.  Defaults to container core limit.
+      example: "2"

--- a/os-java-run/module.yaml
+++ b/os-java-run/module.yaml
@@ -11,3 +11,6 @@ envs:
     - name: JAVA_CORE_LIMIT
       description: Core limit as described in https://www.kernel.org/doc/Documentation/scheduler/sched-bwc.txt.  Used to configure the number of GC threads and parallelism for ForkJoinPool.  Defaults to container core limit.
       example: "2"
+    - name: JAVA_DIAGNOSTICS
+      description: Set this to get some diagnostics information to standard output when things are happening. **Disabled by default.**
+      example: "true"

--- a/os-java-run/module.yaml
+++ b/os-java-run/module.yaml
@@ -21,3 +21,18 @@ envs:
     - name: JAVA_INITIAL_MEM_RATIO
       description: This is used to calculate a default initial heap memory based the maximumal heap memory.  The default is `100` which means 100% of the maximal heap is used for the initial heap size.  You can skip this mechanism by setting this value to `0` in which case no `-Xms` option is added.
       example: "100"
+    - name: GC_MIN_HEAP_FREE_RATIO
+      description: Minimum percentage of heap free after GC to avoid expansion.
+      example: "20"
+    - name: GC_MAX_HEAP_FREE_RATIO
+      description: Maximum percentage of heap free after GC to avoid shrinking.
+      example: "40"
+    - name: GC_TIME_RATIO
+      description: Specifies the ratio of the time spent outside the garbage collection (for example, the time spent for application execution) to the time spent in the garbage collection.
+      example: "4"
+    - name: GC_ADAPTIVE_SIZE_POLICY_WEIGHT
+      description: The weighting given to the current GC time versus previous GC times.
+      example: "90"
+    - name: GC_MAX_METASPACE_SIZE
+      description: The maximum metaspace size.
+      example: "100"

--- a/os-java-run/module.yaml
+++ b/os-java-run/module.yaml
@@ -20,6 +20,9 @@ envs:
     - name: JAVA_INITIAL_MEM_RATIO
       description: This is used to calculate a default initial heap memory based the maximumal heap memory. The default is `100` which means 100% of the maximal heap is used for the initial heap size. You can skip this mechanism by setting this value to `0` in which case no `-Xms` option is added.
       example: "100"
+    - name: JAVA_OPTS_APPEND
+      description: Server startup options.
+      example: "-Dfoo=bar"
     - name: GC_MIN_HEAP_FREE_RATIO
       description: Minimum percentage of heap free after GC to avoid expansion.
       example: "20"

--- a/os-java-run/module.yaml
+++ b/os-java-run/module.yaml
@@ -6,20 +6,19 @@ execute:
 - script: install_as_root
 envs:
     - name: JAVA_MAX_INITIAL_MEM
-      description: The maximum size of the initial heap memory, if the calculated default initial heap is larger then it will be capped at this value.  The default is 4096 MB.
+      description: The maximum size of the initial heap memory, if the calculated default initial heap is larger then it will be capped at this value. The default is 4096 MB.
       example: "4096"
     - name: JAVA_CORE_LIMIT
-      description: Core limit as described in https://www.kernel.org/doc/Documentation/scheduler/sched-bwc.txt.  Used to configure the number of GC threads and parallelism for ForkJoinPool.  Defaults to container core limit.
+      description: Core limit as described in https://www.kernel.org/doc/Documentation/scheduler/sched-bwc.txt. Used to configure the number of GC threads and parallelism for ForkJoinPool. Defaults to container core limit.
       example: "2"
     - name: JAVA_DIAGNOSTICS
       description: Set this to get some diagnostics information to standard output when things are happening. **Disabled by default.**
       example: "true"
     - name: JAVA_MAX_MEM_RATIO
-      description: This is used to calculate a default maximal heap memory based on a containers restriction. If used in a Docker container without any memory constraints for the container then this option has no effect. If there is a memory constraint then `-Xmx` is set to a ratio of the container available memory as set here. The default is `50` which means 50% of the available memory is used as an upper boundary. You can skip this mechanism by setting this value to `0` in which case no `-Xmx` option
-            is added.
+      description: This is used to calculate a default maximal heap memory based on a containers restriction. If used in a container without any memory constraints for the container then this option has no effect. If there is a memory constraint then `-Xmx` is set to a ratio of the container available memory as set here. The default is `50` which means 50% of the available memory is used as an upper boundary. You can skip this mechanism by setting this value to `0` in which case no `-Xmx` option is added.
       example: "50"
     - name: JAVA_INITIAL_MEM_RATIO
-      description: This is used to calculate a default initial heap memory based the maximumal heap memory.  The default is `100` which means 100% of the maximal heap is used for the initial heap size.  You can skip this mechanism by setting this value to `0` in which case no `-Xms` option is added.
+      description: This is used to calculate a default initial heap memory based the maximumal heap memory. The default is `100` which means 100% of the maximal heap is used for the initial heap size. You can skip this mechanism by setting this value to `0` in which case no `-Xms` option is added.
       example: "100"
     - name: GC_MIN_HEAP_FREE_RATIO
       description: Minimum percentage of heap free after GC to avoid expansion.

--- a/os-java-run/module.yaml
+++ b/os-java-run/module.yaml
@@ -14,3 +14,10 @@ envs:
     - name: JAVA_DIAGNOSTICS
       description: Set this to get some diagnostics information to standard output when things are happening. **Disabled by default.**
       example: "true"
+    - name: JAVA_MAX_MEM_RATIO
+      description: This is used to calculate a default maximal heap memory based on a containers restriction. If used in a Docker container without any memory constraints for the container then this option has no effect. If there is a memory constraint then `-Xmx` is set to a ratio of the container available memory as set here. The default is `50` which means 50% of the available memory is used as an upper boundary. You can skip this mechanism by setting this value to `0` in which case no `-Xmx` option
+            is added.
+      example: "50"
+    - name: JAVA_INITIAL_MEM_RATIO
+      description: This is used to calculate a default initial heap memory based the maximumal heap memory.  The default is `100` which means 100% of the maximal heap is used for the initial heap size.  You can skip this mechanism by setting this value to `0` in which case no `-Xms` option is added.
+      example: "100"

--- a/os-jdg-launch/module.yaml
+++ b/os-jdg-launch/module.yaml
@@ -10,3 +10,8 @@ modules:
 execute:
 - script: configure.sh
   user: '185'
+
+run:
+      user: 185
+      cmd:
+          - "/opt/datagrid/bin/openshift-launch.sh"

--- a/os-jdg-launch/module.yaml
+++ b/os-jdg-launch/module.yaml
@@ -5,6 +5,7 @@ description: Legacy os-jdg-launch script package.
 
 modules:
   install:
+  - name: os-eap-launch
   - name: os-eap-migration
 
 execute:
@@ -15,7 +16,3 @@ run:
       user: 185
       cmd:
           - "/opt/datagrid/bin/openshift-launch.sh"
-
-envs:
-    - name: "DEFAULT_ADMIN_USERNAME"
-      value: "eapadmin"

--- a/os-jdg-launch/module.yaml
+++ b/os-jdg-launch/module.yaml
@@ -15,3 +15,7 @@ run:
       user: 185
       cmd:
           - "/opt/datagrid/bin/openshift-launch.sh"
+
+envs:
+    - name: "DEFAULT_ADMIN_USERNAME"
+      value: "eapadmin"

--- a/os-jdg7-launch/module.yaml
+++ b/os-jdg7-launch/module.yaml
@@ -10,3 +10,8 @@ modules:
 execute:
 - script: configure.sh
   user: '185'
+
+run:
+      user: 185
+      cmd:
+          - "/opt/datagrid/bin/openshift-launch.sh"

--- a/os-jdg7-launch/module.yaml
+++ b/os-jdg7-launch/module.yaml
@@ -5,6 +5,7 @@ description: Legacy os-jdg7-launch script package.
 
 modules:
   install:
+  - name: os-eap-launch
   - name: os-eap-migration
 
 execute:
@@ -15,7 +16,3 @@ run:
       user: 185
       cmd:
           - "/opt/datagrid/bin/openshift-launch.sh"
-
-envs:
-    - name: "DEFAULT_ADMIN_USERNAME"
-      value: "eapadmin"

--- a/os-jdg7-launch/module.yaml
+++ b/os-jdg7-launch/module.yaml
@@ -15,3 +15,7 @@ run:
       user: 185
       cmd:
           - "/opt/datagrid/bin/openshift-launch.sh"
+
+envs:
+    - name: "DEFAULT_ADMIN_USERNAME"
+      value: "eapadmin"

--- a/os-jws-launch/module.yaml
+++ b/os-jws-launch/module.yaml
@@ -5,3 +5,7 @@ description: Legacy os-jws-launch script package.
 execute:
 - script: run
   user: '185'
+envs:
+    - name: "ENABLE_ACCESS_LOG"
+      example: "true"
+      description: Enable the Access Log.

--- a/os-sso/module.yaml
+++ b/os-sso/module.yaml
@@ -5,6 +5,6 @@ description: Legacy os-sso script package.
 execute:
 - script: configure.sh
 
-envs:
-    - name: "DEFAULT_ADMIN_USERNAME"
-      value: "eapadmin"
+modules:
+  install:
+  - name: os-eap-launch

--- a/os-sso/module.yaml
+++ b/os-sso/module.yaml
@@ -4,3 +4,7 @@ version: '1.0'
 description: Legacy os-sso script package.
 execute:
 - script: configure.sh
+
+envs:
+    - name: "DEFAULT_ADMIN_USERNAME"
+      value: "eapadmin"

--- a/os-sso71/module.yaml
+++ b/os-sso71/module.yaml
@@ -6,6 +6,7 @@ description: Legacy os-sso71 script package.
 modules:
   install:
   - name: os-eap-launch
+  - name: os-eap7-launch
   - name: os-eap-migration
 
 execute:
@@ -15,8 +16,3 @@ run:
       user: 185
       cmd:
           - "/opt/eap/bin/openshift-launch.sh"
-
-envs:
-    - name: "CLI_GRACEFUL_SHUTDOWN"
-      example: "true"
-      description: "If set to any non zero length value then the image will prevent shutdown with the TERM signal and will require execution of the shutdown command through jboss-cli."

--- a/os-sso71/module.yaml
+++ b/os-sso71/module.yaml
@@ -5,6 +5,7 @@ description: Legacy os-sso71 script package.
 
 modules:
   install:
+  - name: os-eap-launch
   - name: os-eap-migration
 
 execute:
@@ -16,8 +17,6 @@ run:
           - "/opt/eap/bin/openshift-launch.sh"
 
 envs:
-    - name: "DEFAULT_ADMIN_USERNAME"
-      value: "eapadmin"
     - name: "CLI_GRACEFUL_SHUTDOWN"
       example: "true"
       description: "If set to any non zero length value then the image will prevent shutdown with the TERM signal and will require execution of the shutdown command through jboss-cli."

--- a/os-sso71/module.yaml
+++ b/os-sso71/module.yaml
@@ -9,3 +9,8 @@ modules:
 
 execute:
 - script: configure.sh
+
+run:
+      user: 185
+      cmd:
+          - "/opt/eap/bin/openshift-launch.sh"

--- a/os-sso71/module.yaml
+++ b/os-sso71/module.yaml
@@ -18,3 +18,6 @@ run:
 envs:
     - name: "DEFAULT_ADMIN_USERNAME"
       value: "eapadmin"
+    - name: "CLI_GRACEFUL_SHUTDOWN"
+      example: "true"
+      description: "If set to any non zero length value then the image will prevent shutdown with the TERM signal and will require execution of the shutdown command through jboss-cli."

--- a/os-sso71/module.yaml
+++ b/os-sso71/module.yaml
@@ -14,3 +14,7 @@ run:
       user: 185
       cmd:
           - "/opt/eap/bin/openshift-launch.sh"
+
+envs:
+    - name: "DEFAULT_ADMIN_USERNAME"
+      value: "eapadmin"

--- a/os-sso72/module.yaml
+++ b/os-sso72/module.yaml
@@ -20,3 +20,7 @@ run:
       user: 185
       cmd:
           - "/opt/eap/bin/openshift-launch.sh"
+
+envs:
+    - name: "DEFAULT_ADMIN_USERNAME"
+      value: "eapadmin"

--- a/os-sso72/module.yaml
+++ b/os-sso72/module.yaml
@@ -24,3 +24,6 @@ run:
 envs:
     - name: "DEFAULT_ADMIN_USERNAME"
       value: "eapadmin"
+    - name: "CLI_GRACEFUL_SHUTDOWN"
+      example: "true"
+      description: "If set to any non zero length value then the image will prevent shutdown with the TERM signal and will require execution of the shutdown command through jboss-cli."

--- a/os-sso72/module.yaml
+++ b/os-sso72/module.yaml
@@ -5,6 +5,7 @@ description: Legacy os-sso72 script package.
 
 modules:
   install:
+  - name: os-eap-launch
   - name: os-eap-migration
 
 packages:
@@ -22,8 +23,6 @@ run:
           - "/opt/eap/bin/openshift-launch.sh"
 
 envs:
-    - name: "DEFAULT_ADMIN_USERNAME"
-      value: "eapadmin"
     - name: "CLI_GRACEFUL_SHUTDOWN"
       example: "true"
       description: "If set to any non zero length value then the image will prevent shutdown with the TERM signal and will require execution of the shutdown command through jboss-cli."

--- a/os-sso72/module.yaml
+++ b/os-sso72/module.yaml
@@ -15,3 +15,8 @@ packages:
 
 execute:
 - script: configure.sh
+
+run:
+      user: 185
+      cmd:
+          - "/opt/eap/bin/openshift-launch.sh"

--- a/os-sso72/module.yaml
+++ b/os-sso72/module.yaml
@@ -6,6 +6,7 @@ description: Legacy os-sso72 script package.
 modules:
   install:
   - name: os-eap-launch
+  - name: os-eap7-launch
   - name: os-eap-migration
 
 packages:
@@ -21,8 +22,3 @@ run:
       user: 185
       cmd:
           - "/opt/eap/bin/openshift-launch.sh"
-
-envs:
-    - name: "CLI_GRACEFUL_SHUTDOWN"
-      example: "true"
-      description: "If set to any non zero length value then the image will prevent shutdown with the TERM signal and will require execution of the shutdown command through jboss-cli."


### PR DESCRIPTION

Also, while at this, squeeze the double space character in descriptions of certain environment variables into single one

<b>Note:</b> Since this PR [depends on ```cct_module``` change for CLOUD-2413 made by Jonathan](https://github.com/jboss-openshift/cct_module/pull/222), it can be merged only <b>after</b> the [CLOUD-2413](https://issues.jboss.org/browse/CLOUD-2413) changes have been merged.
    
Signed-off-by: Jan Lieskovsky <jlieskov@redhat.com>

Thanks for submitting your Pull Request!

Please make sure your PR meets following requirements:

- [ ] Pull Request title is properly formatted: `[CLOUD-XYA] Subject`
- [ ] Pull Request contains link to the JIRA issue
- [ ] Pull Request contains description of the issue
- [ ] Pull request does not include fixes for other issues than the main ticket
- [ ] Attached commits represent unit of work and are properly formatted
- [ ] You have read and agreed to the Developer Certificate of Origin (DCO) (see `CONTRIBUTING.md`)
- [ ] Every commit contains `Signed-off-by: Your Name <yourname@redhat.com>` - use `git commit -s`
