### PR TITLE
[CLOUD-2629] EAP openshift-launch.sh doesn't trap INT

### DIFF
--- a/os-eap7-launch/added/openshift-launch.sh
+++ b/os-eap7-launch/added/openshift-launch.sh
@@ -22,6 +22,7 @@ function runServer() {
   log_info "Running $JBOSS_IMAGE_NAME image, version $JBOSS_IMAGE_VERSION"
 
   trap "clean_shutdown" TERM
+  trap "clean_shutdown" INT
 
   if [ -n "$CLI_GRACEFUL_SHUTDOWN" ] ; then
     trap "" TERM
@@ -54,6 +55,7 @@ else
   log_info "Running $JBOSS_IMAGE_NAME image, version $JBOSS_IMAGE_VERSION"
 
   trap "clean_shutdown" TERM
+  trap "clean_shutdown" INT
 
   if [ -n "$CLI_GRACEFUL_SHUTDOWN" ] ; then
     trap "" TERM


### PR DESCRIPTION
https://issues.jboss.org/browse/CLOUD-2629
Signed-off-by: Ken Wills <kwills@redhat.com>

Thanks for submitting your Pull Request!

Please make sure your PR meets following requirements:

- [ ] Pull Request title is properly formatted: `[CLOUD-XYA] Subject`
- [ ] Pull Request contains link to the JIRA issue
- [ ] Pull Request contains description of the issue
- [ ] Pull request does not include fixes for other issues than the main ticket
- [ ] Attached commits represent unit of work and are properly formatted
- [ ] You have read and agreed to the Developer Certificate of Origin (DCO) (see `CONTRIBUTING.md`)
- [ ] Every commit contains `Signed-off-by: Your Name <yourname@redhat.com>` - use `git commit -s`
