### PR TITLE
[CLOUD-2647] AMQ broker pod blocked when split-x folder is locked by A…

### DIFF
--- a/os-partition/added/partitionPV.sh
+++ b/os-partition/added/partitionPV.sh
@@ -33,12 +33,14 @@ function partitionPV() {
           if [ -z "$TERMINATING" ] ; then
             # Not terminating, grab the lock without waiting
             flock -n $LOCK_FD
+            LOCK_STATUS=$?
           else
             REMAINING_LOCKING_TIME=$LOCK_TIMEOUT
             echo "Existing server instance is terminating, attempting lock per second for $LOCK_TIMEOUT seconds"
 
             while : ; do
               flock -n $LOCK_FD
+              LOCK_STATUS=$?
               if [ $? -eq 0 ]; then
                 # Grabbed the lock successfully
                 break
@@ -53,7 +55,6 @@ function partitionPV() {
               sleep 1
             done
           fi
-          LOCK_STATUS=$?
         fi
         if [ $LOCK_STATUS -eq 0 ] ; then
           echo "Successfully locked directory: ($INSTANCE_DIR)"

--- a/os-partition/added/partitionPV.sh
+++ b/os-partition/added/partitionPV.sh
@@ -39,11 +39,11 @@ function partitionPV() {
 
             while : ; do
               flock -n $LOCK_FD
-              if [$? -eq 0 ]; then
+              if [ $? -eq 0 ]; then
                 # Grabbed the lock successfully
                 break
               fi
-              $REMAINING_LOCKING_TIME=$(expr $REMAINING_LOCKING_TIME - 1)
+              REMAINING_LOCKING_TIME=$(expr $REMAINING_LOCKING_TIME - 1)
               if [ "$REMAINING_LOCKING_TIME" -le 0 ] ; then
                 # No more time to wait for the lock
                 break

--- a/os-partition/added/partitionPV.sh
+++ b/os-partition/added/partitionPV.sh
@@ -41,7 +41,7 @@ function partitionPV() {
             while : ; do
               flock -n $LOCK_FD
               LOCK_STATUS=$?
-              if [ $? -eq 0 ]; then
+              if [ $LOCK_STATUS -eq 0 ]; then
                 # Grabbed the lock successfully
                 break
               fi


### PR DESCRIPTION
…MQ Drainer pod

* When terminating changed the flock -w, i.e. waiting, to flock -n, no waiting
* Updated the log message for the terminating case to indicate no waiting
* https://issues.jboss.org/browse/CLOUD-2647

Signed-off-by: Roddie Kieley <rkieley@redhat.com>


Thanks for submitting your Pull Request!

Please make sure your PR meets following requirements:

- [X] Pull Request title is properly formatted: `[CLOUD-XYA] Subject`
- [X] Pull Request contains link to the JIRA issue
- [X] Pull Request contains description of the issue
- [X] Pull request does not include fixes for other issues than the main ticket
- [X] Attached commits represent unit of work and are properly formatted
- [X] You have read and agreed to the Developer Certificate of Origin (DCO) (see `CONTRIBUTING.md`)
- [X] Every commit contains `Signed-off-by: Your Name <yourname@redhat.com>` - use `git commit -s`
