### PR TITLE
[CLOUD-2286] permit user configuration of GC

### DIFF
--- a/os-java-run/added/java-default-options
+++ b/os-java-run/added/java-default-options
@@ -117,10 +117,11 @@ gc_config() {
   local timeRatio=${GC_TIME_RATIO:-4}
   local adaptiveSizePolicyWeight=${GC_ADAPTIVE_SIZE_POLICY_WEIGHT:-90}
   local maxMetaspaceSize=${GC_MAX_METASPACE_SIZE:-100}
+  local gcOptions="${GC_CONTAINER_OPTIONS:--XX:+UseParallelOldGC}"
 
-  echo "-XX:+UnlockExperimentalVMOptions " \
-       "-XX:+UseCGroupMemoryLimitForHeap " \
-       "-XX:+UseParallelOldGC " \
+  echo "${gcOptions}" \
+       "-XX:+UnlockExperimentalVMOptions "\
+       "-XX:+UseCGroupMemoryLimitForHeap "\
        "-XX:MinHeapFreeRatio=${minHeapFreeRatio} "\
        "-XX:MaxHeapFreeRatio=${maxHeapFreeRatio} "\
        "-XX:GCTimeRatio=${timeRatio} "\

--- a/os-java-run/module.yaml
+++ b/os-java-run/module.yaml
@@ -38,3 +38,6 @@ envs:
     - name: GC_MAX_METASPACE_SIZE
       description: The maximum metaspace size.
       example: "100"
+    - name: GC_CONTAINER_OPTIONS
+      description: specify Java GC to use. The value of this variable should contain the necessary JRE command-line options to specify the required GC, which will override the default of `-XX:+UseParallelOldGC`.
+      example: -XX:+UseG1GC

--- a/tests/features/java/gc.feature
+++ b/tests/features/java/gc.feature
@@ -40,3 +40,11 @@ Feature: Openshift OpenJDK GC tests
        | GC_MAX_METASPACE_SIZE    | 120    |
     Then s2i build log should contain Setting MAVEN_OPTS to -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap -XX:+UseParallelOldGC -XX:MinHeapFreeRatio=10 -XX:MaxHeapFreeRatio=20 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90 -XX:MaxMetaspaceSize=120m
     And container log should contain -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap -XX:+UseParallelOldGC -XX:MinHeapFreeRatio=10 -XX:MaxHeapFreeRatio=20 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90 -XX:MaxMetaspaceSize=120m
+
+  Scenario: Check GC_CONTAINER_OPTIONS configuration
+    Given s2i build https://github.com/jboss-openshift/openshift-quickstarts from undertow-servlet
+       | variable             | value        |
+       | GC_CONTAINER_OPTIONS | -XX:+UseG1GC |
+    Then s2i build log should contain Setting MAVEN_OPTS to -XX:+UseG1GC
+    And container log should contain -XX:+UseG1GC
+    And container log should not contain -XX:+UseParallelOldGC


### PR DESCRIPTION
Move hard-coded GC options into a "GC_OPTIONS" environment variable
that can be user-supplied to override the defaults.

https://issues.jboss.org/browse/CLOUD-2286