### PR TITLE
CLOUD-2706 update JSON logging to capture server boot

### DIFF
--- a/os-eap-logging/added/logging.properties
+++ b/os-eap-logging/added/logging.properties
@@ -32,7 +32,7 @@ handlers=CONSOLE
 
 handler.CONSOLE=org.jboss.logmanager.handlers.ConsoleHandler
 handler.CONSOLE.level=ALL
-handler.CONSOLE.formatter=COLOR-PATTERN
+handler.CONSOLE.formatter=##CONSOLE-FORMATTER##
 handler.CONSOLE.properties=autoFlush,target,enabled
 handler.CONSOLE.autoFlush=true
 handler.CONSOLE.target=SYSTEM_OUT

--- a/os-eap7-launch/added/launch/json_logging.sh
+++ b/os-eap7-launch/added/launch/json_logging.sh
@@ -7,7 +7,9 @@ function configure_json_logging() {
 
   if [ "${ENABLE_JSON_LOGGING^^}" == "TRUE" ]; then
     sed -i 's|##CONSOLE-FORMATTER##|OPENSHIFT|' $CONFIG_FILE
+    sed -i 's|##CONSOLE-FORMATTER##|OPENSHIFT|' $LOGGING_FILE
   else
     sed -i 's|##CONSOLE-FORMATTER##|COLOR-PATTERN|' $CONFIG_FILE
+    sed -i 's|##CONSOLE-FORMATTER##|COLOR-PATTERN|' $LOGGING_FILE
   fi
 }


### PR DESCRIPTION
https://issues.jboss.org/browse/CLOUD-2706
Signed-off-by: Ken Wills <kwills@redhat.com>

See also https://github.com/jboss-container-images/jboss-eap-modules/pull/17 for an associated, required change to support this behavior on EAP CD.

Thanks for submitting your Pull Request!

Please make sure your PR meets following requirements:

- [ ] Pull Request title is properly formatted: `[CLOUD-XYA] Subject`
- [ ] Pull Request contains link to the JIRA issue
- [ ] Pull Request contains description of the issue
- [ ] Pull request does not include fixes for other issues than the main ticket
- [ ] Attached commits represent unit of work and are properly formatted
- [ ] You have read and agreed to the Developer Certificate of Origin (DCO) (see `CONTRIBUTING.md`)
- [ ] Every commit contains `Signed-off-by: Your Name <yourname@redhat.com>` - use `git commit -s`
