### PR TITLE
[CLOUD-2759] Jolokia probe's DeploymentTest should succeed if the JMX…

### DIFF
--- a/os-eap-probes/added/probes/probe/eap/jolokia.py
+++ b/os-eap-probes/added/probes/probe/eap/jolokia.py
@@ -121,6 +121,9 @@ class DeploymentTest(Test):
             FAILURE if the query failed or if any deployments are not OK, but not FAILED
         """
 
+        if results["status"] == 404:
+            return (Status.READY, "No deployments")
+
         if results["status"] != 200:
             return (Status.FAILURE, "Jolokia query failed")
 


### PR DESCRIPTION
… query results in a 404

https://issues.jboss.org/browse/CLOUD-2759
Signed-off-by: Brian Stansberry <brian.stansberry@redhat.com>

Note that the "status": 404 that's treated as acceptable here is not an HTTP 404 for the overall HTTP request to the server. It's a jolokia protocol value for the particular JMX query invoked by this probe test, with '404' used to indicate that the query didn't match any mbeans. Which is ok; no match means no failed deployments.

Thanks for submitting your Pull Request!

Please make sure your PR meets following requirements:

- [ ] Pull Request title is properly formatted: `[CLOUD-XYA] Subject`
- [ ] Pull Request contains link to the JIRA issue
- [ ] Pull Request contains description of the issue
- [ ] Pull request does not include fixes for other issues than the main ticket
- [ ] Attached commits represent unit of work and are properly formatted
- [ ] You have read and agreed to the Developer Certificate of Origin (DCO) (see `CONTRIBUTING.md`)
- [ ] Every commit contains `Signed-off-by: Your Name <yourname@redhat.com>` - use `git commit -s`
