### PR TITLE
[CLOUD-2767] setting bigger timeout for recovery scan

### DIFF
--- a/os-eap-migration/added/launch/openshift-migrate-common.sh
+++ b/os-eap-migration/added/launch/openshift-migrate-common.sh
@@ -48,9 +48,9 @@ function runMigration() {
       recoveryJar=$(find "${JBOSS_HOME}" -name \*.jar | xargs grep -l "${recoveryClass}")
       if [ -n "${recoveryJar}" ] ; then
         echo "$(date): Executing synchronous recovery scan for a first time"
-        java -cp "${recoveryJar}" "${recoveryClass}" -host "${recoveryHost}" -port "${recoveryPort}"
+        java -cp "${recoveryJar}" "${recoveryClass}" -host "${recoveryHost}" -port "${recoveryPort}" -timeout 1800000
         echo "$(date): Executing synchronous recovery scan for a second time"
-        java -cp "${recoveryJar}" "${recoveryClass}" -host "${recoveryHost}" -port "${recoveryPort}"
+        java -cp "${recoveryJar}" "${recoveryClass}" -host "${recoveryHost}" -port "${recoveryPort}" -timeout 1800000
         echo "$(date): Synchronous recovery scans finished for the first and the second time"
       fi
     fi


### PR DESCRIPTION
https://issues.jboss.org/browse/CLOUD-2767

Setting the socket timeout of the recovery request to 30 minutes while expecting whole recovery process (both phases) will be run in such time.
From the perspective of the script we need to ensure that scan is completly finished and only then server shutdown is requested.