### PR TITLE
Add disable-zdravo module

### DIFF
--- a/disable-zdravo/bot-cfg.yml
+++ b/disable-zdravo/bot-cfg.yml
@@ -1,0 +1,3 @@
+version: "1"
+zdravomil:
+  enabled: no

--- a/disable-zdravo/module.yaml
+++ b/disable-zdravo/module.yaml
@@ -1,0 +1,8 @@
+schema_version: 1
+
+name: disable-zdravo
+description: adds configuration to disable the Zdravomil Dockerfile linter bot
+
+artifacts:
+- path: bot-cfg.yml
+  sha256: 5f0af3f1ef4453033d6a13a054aedcd7c50e826f09394f6382a467d1be547bb1


### PR DESCRIPTION
This module adds a bot-cfg.yml file to the generate output, which
instructs the Zdravomil Dockerfile linter bot to ignore this image.