### PR TITLE
[CLOUD-2406] Fix and improve Elytron configuration integration

### DIFF
--- a/os-eap7-launch/added/launch/elytron.sh
+++ b/os-eap7-launch/added/launch/elytron.sh
@@ -72,7 +72,17 @@ function configure_https() {
 
     https_connector="<https-listener name=\"https\" socket-binding=\"https\" ssl-context=\"LocalhostSslContext\" proxy-address-forwarding=\"true\"/>"
   elif [ -n "${HTTPS_PASSWORD}" -o -n "${HTTPS_KEYSTORE}" -o -n "${HTTPS_KEYSTORE_TYPE}" ]; then
-    echo "WARNING! Partial HTTPS configuration, the https connector WILL NOT be configured."
+    local missing_msg="WARNING! Partial HTTPS configuration, the https connector WILL NOT be configured. Missing:"
+    if [ -z "${HTTPS_PASSWORD}" ]; then
+      missing_msg="$missing_msg HTTPS_PASSWORD"
+    fi
+    if [ -z "${HTTPS_KEYSTORE}" ]; then
+      missing_msg="$missing_msg HTTPS_KEYSTORE"
+    fi
+    if [ -z "${HTTPS_KEYSTORE_TYPE}" ]; then
+      missing_msg="$missing_msg HTTPS_KEYSTORE_TYPE"
+    fi
+    echo $missing_msg
   fi
 
   sed -i "s|<!-- ##TLS## -->|${tls}|" $CONFIG_FILE

--- a/os-eap7-launch/added/launch/elytron.sh
+++ b/os-eap7-launch/added/launch/elytron.sh
@@ -31,6 +31,9 @@ function configure_https() {
 
     if [ -n "${HTTPS_KEY_PASSWORD}" ]; then
       key_password="<credential-reference clear-text=\"${HTTPS_KEY_PASSWORD}\"/>"
+    else
+      echo "No HTTPS_KEY_PASSWORD was provided; using HTTPS_PASSWORD for Elytron LocalhostKeyManager."
+      key_password="<credential-reference clear-text=\"${HTTPS_PASSWORD}\"/>"
     fi
 
     tls="<tls>\n\


### PR DESCRIPTION
https://issues.jboss.org/browse/CLOUD-2406

* Default HTTPS_KEY_PASSWORD to HTTPS_PASSWORD
* Don't require HTTPS_KEYSTORE_DIR; use jboss.server.config.dir path if not set
* If HTTPS_KEYSTORE_DIR starts with '/' treat it as an absolute path, else as config model path name
* If settings are mssing, state what they are

Please make sure your PR meets following requirements:

- [X ] Pull Request title is properly formatted: `[CLOUD-XYA] Subject`
- [ X] Pull Request contains link to the JIRA issue
- [X ] Pull Request contains description of the issue
- [X ] Pull request does not include fixes for other issues than the main ticket
- [X ] Attached commits represent unit of work and are properly formatted
- [X ] You have read and agreed to the Developer Certificate of Origin (DCO) (see `CONTRIBUTING.md`)
- [X ] Every commit contains `Signed-off-by: Your Name <yourname@redhat.com>` - use `git commit -s`
