### PR TITLE
[CLOUD-2364] allow overriding of JBOSS_HA_ARGS IP address

### DIFF
--- a/os-eap7-launch/added/launch/ha.sh
+++ b/os-eap7-launch/added/launch/ha.sh
@@ -65,7 +65,7 @@ function validate_ping_protocol() {
 function configure_ha() {
   # Set HA args
   IP_ADDR=`hostname -i`
-  JBOSS_HA_ARGS="-b ${IP_ADDR} -bprivate ${IP_ADDR}"
+  JBOSS_HA_ARGS="-b ${JBOSS_HA_IP:-${IP_ADDR}} -bprivate ${JBOSS_HA_IP:-${IP_ADDR}}"
 
   init_node_name
 

--- a/os-eap7-launch/module.yaml
+++ b/os-eap7-launch/module.yaml
@@ -31,3 +31,6 @@ envs:
     - name: "ENABLE_JSON_LOGGING"
       example: "true"
       description: Enable JSON-formatted logging
+    - name: "JBOSS_HA_IP"
+      example: "0.0.0.0"
+      description: "Override the default HA bind address (default value is the result of 'hostname -i') with a specific address."


### PR DESCRIPTION
https://issues.jboss.org/browse/CLOUD-2364
Signed-off-by: Ken Wills <kwills@redhat.com>

Adds JBOSS_HA_IP to allow overriding of the currently used 'hostname -i' value.

Thanks for submitting your Pull Request!

Please make sure your PR meets following requirements:

- [ ] Pull Request title is properly formatted: `[CLOUD-XYA] Subject`
- [ ] Pull Request contains link to the JIRA issue
- [ ] Pull Request contains description of the issue
- [ ] Pull request does not include fixes for other issues than the main ticket
- [ ] Attached commits represent unit of work and are properly formatted
- [ ] You have read and agreed to the Developer Certificate of Origin (DCO) (see `CONTRIBUTING.md`)
- [ ] Every commit contains `Signed-off-by: Your Name <yourname@redhat.com>` - use `git commit -s`
