### PR TITLE
[CLOUD-2895] check both /net/tcp6 and /net/tcp for open ports in read…

### DIFF
--- a/os-amq-launch/added/readinessProbe.sh
+++ b/os-amq-launch/added/readinessProbe.sh
@@ -22,23 +22,26 @@ import socket
 import sys
 
 # calculate the open ports
-try:
-  tcp_file = open("/proc/net/tcp6", "r")
-except IOError:
-  tcp_file = open("/proc/net/tcp", "r")
-tcp_lines = tcp_file.readlines()
-header = tcp_lines.pop(0)
-tcp_file.close()
-
 listening_ports = []
-for tcp_line in tcp_lines:
-  stripped = tcp_line.strip()
-  contents = stripped.split()
-  # Is the status listening?
-  if contents[3] == '0A':
-    netaddr = contents[1].split(":")
-    port = int(netaddr[1], 16)
-    listening_ports.append(port)
+inputs = ["/proc/net/tcp6", "/proc/net/tcp"]
+for input in inputs:
+  try:
+    tcp_file = open(input, "r")
+    tcp_lines = tcp_file.readlines()
+    header = tcp_lines.pop(0)
+    tcp_file.close()
+
+    for tcp_line in tcp_lines:
+      stripped = tcp_line.strip()
+      contents = stripped.split()
+      # Is the status listening?
+      if contents[3] == '0A':
+        netaddr = contents[1].split(":")
+        port = int(netaddr[1], 16)
+        listening_ports.append(port)
+
+  except IOError:
+   pass
 
 #parse the config file to retrieve the transport connectors
 xmldoc = xml.etree.ElementTree.parse("${CONFIG_FILE}")


### PR DESCRIPTION
…iness probe

Signed-off-by: gtully <gary.tully@gmail.com>

Thanks for submitting your Pull Request!

https://issues.jboss.org/browse/CLOUD-2895

Please make sure your PR meets following requirements:

- [ ] Pull Request title is properly formatted: `[CLOUD-XYA] Subject`
- [ ] Pull Request contains link to the JIRA issue
- [ ] Pull Request contains description of the issue
- [ ] Pull request does not include fixes for other issues than the main ticket
- [ ] Attached commits represent unit of work and are properly formatted
- [ ] You have read and agreed to the Developer Certificate of Origin (DCO) (see `CONTRIBUTING.md`)
- [ ] Every commit contains `Signed-off-by: Your Name <yourname@redhat.com>` - use `git commit -s`
