### PR TITLE
CLOUD-2842 - Xms and Xms are different when limits are higher than 5Gi using JAVA_MAX_MEM_RATIO and JAVA_INITIAL_MEM_RATIO

### DIFF
--- a/os-java-run/added/java-default-options
+++ b/os-java-run/added/java-default-options
@@ -83,7 +83,13 @@ initial_memory() {
     if [ "${ms}" -lt "${max_initial_memory}" ] ; then
       echo "-Xms${ms}m"
     else
-      echo "-Xms${max_initial_memory}m"
+      # check if JAVA_MAX_INITIAL_MEM is unset. If it is we need to check if ms > max_initial_memory and use the larger value
+      # instead of the default
+      if [ "x${JAVA_MAX_INITIAL_MEM}" = "x" ] && [ "${ms}" -gt "${max_initial_memory}" ]; then
+            echo "-Xms${ms}m"
+      else
+        echo "-Xms${max_initial_memory}m"
+      fi
     fi
   fi
 }

--- a/tests/features/eap/eap_gc.feature
+++ b/tests/features/eap/eap_gc.feature
@@ -1,5 +1,5 @@
 @jboss-eap-6/eap64-openshift @jboss-eap-7 @jboss-decisionserver-6 @jboss-processserver-6 @jboss-datagrid-6 @jboss-datagrid-7 @jboss-datavirt-6 @jboss-eap-7-tech-preview
-Feature: Openshift OpenJDK GC tests
+Feature: EAP Openshift OpenJDK GC tests
 
   Scenario: Check default GC configuration
     When container is ready
@@ -81,6 +81,22 @@ Feature: Openshift OpenJDK GC tests
       | mem_limit              | 1073741824        |
     Then container log should match regex ^ *JAVA_OPTS: *.* -Xms128m\s
       And container log should match regex ^ *JAVA_OPTS: *.* -Xmx512m\s
+
+  Scenario: CLOUD-2842 mem_limit greater than default limit
+    When container is started with args
+      | arg       | value                         |
+      | mem_limit | 6442450944                    |
+      | env_json  | {"JAVA_INITIAL_MEM_RATIO": 100.0, "JAVA_MAX_MEM_RATIO": 100.0} |
+    Then container log should match regex ^ *JAVA_OPTS: *.* -Xms6144m\s
+      And container log should match regex ^ *JAVA_OPTS: *.* -Xmx6144m\s
+
+  Scenario: CLOUD-2842 mem_limit less than default limit
+    When container is started with args
+      | arg       | value                         |
+      | mem_limit | 6442450944                    |
+      | env_json  | {"JAVA_INITIAL_MEM_RATIO": 50.0, "JAVA_MAX_MEM_RATIO": 100} |
+    Then container log should match regex ^ *JAVA_OPTS: *.* -Xms3072m\s
+      And container log should match regex ^ *JAVA_OPTS: *.* -Xmx6144m\s
 
   # CLOUD-459 (override default heap size)
   Scenario: CLOUD-459 Check for adjusted default heap size


### PR DESCRIPTION
https://issues.jboss.org/browse/CLOUD-2842
signed-off-by: Ken Wills <kwills@redhat.com>

Thanks for submitting your Pull Request!

Please make sure your PR meets following requirements:

- [ ] Pull Request title is properly formatted: `[CLOUD-XYA] Subject`
- [ ] Pull Request contains link to the JIRA issue
- [ ] Pull Request contains description of the issue
- [ ] Pull request does not include fixes for other issues than the main ticket
- [ ] Attached commits represent unit of work and are properly formatted
- [ ] You have read and agreed to the Developer Certificate of Origin (DCO) (see `CONTRIBUTING.md`)
- [ ] Every commit contains `Signed-off-by: Your Name <yourname@redhat.com>` - use `git commit -s`
