### PR TITLE
[CLOUD-2058] - JBoss on Openshift does not start when the java security manager is enabled

### DIFF
--- a/jolokia/added/standalone.conf
+++ b/jolokia/added/standalone.conf
@@ -11,4 +11,7 @@ export AB_JOLOKIA_PORT
 # add jolokia options
 JAVA_OPTS="${JAVA_OPTS} $(/opt/jolokia/jolokia-opts)"
 
+if [ "x${SECMGR}" = "xtrue" ]; then
+  JAVA_OPTS="$JAVA_OPTS -Dsun.util.logging.disableCallerCheck=true"
+fi
 JAVA_OPTS="$JAVA_OPTS -Xbootclasspath/p:${JBOSS_MODULES_JAR}:${JBOSS_LOGMANAGER_JAR}:${JBOSS_LOGMANAGER_EXT_JAR} -Djava.util.logging.manager=org.jboss.logmanager.LogManager"


### PR DESCRIPTION
https://issues.jboss.org/browse/CLOUD-2058
Signed-off-by: Ken Wills <kwills@redhat.com>

Thanks for submitting your Pull Request!

Please make sure your PR meets following requirements:

- [ ] Pull Request title is properly formatted: `[CLOUD-XYA] Subject`
- [ ] Pull Request contains link to the JIRA issue
- [ ] Pull Request contains description of the issue
- [ ] Pull request does not include fixes for other issues than the main ticket
- [ ] Attached commits represent unit of work and are properly formatted
- [ ] You have read and agreed to the Developer Certificate of Origin (DCO) (see `CONTRIBUTING.md`)
- [ ] Every commit contains `Signed-off-by: Your Name <yourname@redhat.com>` - use `git commit -s`
