### PR TITLE
CLOUD-2821 fix http.nonProxyHosts escaping for amq

### DIFF
--- a/os-amq-launch/added/drain.sh
+++ b/os-amq-launch/added/drain.sh
@@ -27,6 +27,8 @@ fi
 # Add proxy command line options
 source /opt/run-java/proxy-options
 ACTIVEMQ_OPTS="$ACTIVEMQ_OPTS $(proxy_options)"
+opts_array=($ACTIVEMQ_OPTS)
+ACTIVEMQ_OPTS=$(printf "%q " ${opts_array[@]})
 
 function runMigration() {
     export ACTIVEMQ_DATA="$1"

--- a/os-amq-launch/added/launch.sh
+++ b/os-amq-launch/added/launch.sh
@@ -25,9 +25,9 @@ fi
 
 # Add proxy command line options
 source /opt/run-java/proxy-options
-options="$(proxy_options)"
-options="$(echo $options | sed 's|"|\\"|g')"
-ACTIVEMQ_OPTS="$ACTIVEMQ_OPTS $options"
+ACTIVEMQ_OPTS="$ACTIVEMQ_OPTS $(proxy_options)"
+opts_array=($ACTIVEMQ_OPTS)
+ACTIVEMQ_OPTS=$(printf "%q " ${opts_array[@]})
 
 # Add jolokia command line options
 cat <<EOF > $AMQ_HOME/bin/env

--- a/tests/features/amq/amq-common.feature
+++ b/tests/features/amq/amq-common.feature
@@ -214,10 +214,11 @@ Feature: Openshift AMQ tests
 
   Scenario: check nonHttpProxy escaping
     When container is started with env
-       | variable                  | value           |
-       | NO_PROXY                  | patriots.com    |
+       | variable                  | value                 |
+       | NO_PROXY                  | patriots.com,127.*    |
     Then container log should contain INFO | Apache ActiveMQ 5.11.0.redhat-
-    And file /opt/amq/bin/env should contain -Dhttp.nonProxyHosts=patriots.com
+    And container log should contain -Dhttp.nonProxyHosts=patriots.com|127.*
+    And file /opt/amq/bin/env should contain -Dhttp.nonProxyHosts=patriots.com\|127.\*
   
   Scenario: check queue memory limit
     Given XML namespace amq:http://activemq.apache.org/schema/core


### PR DESCRIPTION
Signed-off-by: rcernich <rcernich@redhat.com>

Thanks for submitting your Pull Request!

Please make sure your PR meets following requirements:

- [ ] Pull Request title is properly formatted: `[CLOUD-XYA] Subject`
- [ ] Pull Request contains link to the JIRA issue
- [ ] Pull Request contains description of the issue
- [ ] Pull request does not include fixes for other issues than the main ticket
- [ ] Attached commits represent unit of work and are properly formatted
- [ ] You have read and agreed to the Developer Certificate of Origin (DCO) (see `CONTRIBUTING.md`)
- [ ] Every commit contains `Signed-off-by: Your Name <yourname@redhat.com>` - use `git commit -s`
