### PR TITLE
CLOUD-2689: jboss.container.java.certs module

### DIFF
--- a/jboss/container/java/certs/bash/artifacts/trust-ose-cert.sh
+++ b/jboss/container/java/certs/bash/artifacts/trust-ose-cert.sh
@@ -2,8 +2,8 @@
 set -u
 set -e
 
-cp /var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt \
-	/etc/pki/ca-trust/source/anchors/
-/usr/bin/update-ca-trust
-
-
+ca=/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt
+if test -r "$ca" ; then
+    cp "$ca" /etc/pki/ca-trust/source/anchors/
+    /usr/bin/update-ca-trust
+fi

--- a/jboss/container/java/certs/bash/artifacts/trust-ose-cert.sh
+++ b/jboss/container/java/certs/bash/artifacts/trust-ose-cert.sh
@@ -2,9 +2,7 @@
 set -e
 
 if [ -z "$JAVA_DISABLE_TRUST_OPENSHIFT_CA" ]; then
-    ca=/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt
-    if test -r "$ca" ; then
-        cp "$ca" /etc/pki/ca-trust/source/anchors/
+    if test -r "/etc/pki/ca-trust/source/anchors/ose-service-ca.crt" ; then
         /usr/bin/update-ca-trust
     fi
 fi

--- a/jboss/container/java/certs/bash/artifacts/trust-ose-cert.sh
+++ b/jboss/container/java/certs/bash/artifacts/trust-ose-cert.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+set -u
+set -e
+
+cp /var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt \
+	/etc/pki/ca-trust/source/anchors/
+/usr/bin/update-ca-trust
+
+

--- a/jboss/container/java/certs/bash/artifacts/trust-ose-cert.sh
+++ b/jboss/container/java/certs/bash/artifacts/trust-ose-cert.sh
@@ -1,9 +1,10 @@
 #!/bin/sh
-set -u
 set -e
 
-ca=/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt
-if test -r "$ca" ; then
-    cp "$ca" /etc/pki/ca-trust/source/anchors/
-    /usr/bin/update-ca-trust
+if [ -z "$JAVA_DISABLE_TRUST_OPENSHIFT_CA" ]; then
+    ca=/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt
+    if test -r "$ca" ; then
+        cp "$ca" /etc/pki/ca-trust/source/anchors/
+        /usr/bin/update-ca-trust
+    fi
 fi

--- a/jboss/container/java/certs/bash/configure.sh
+++ b/jboss/container/java/certs/bash/configure.sh
@@ -16,3 +16,6 @@ d=/opt/jboss/container/java/certs
 mkdir -p "$d"
 cp "${ARTIFACTS_DIR}/trust-ose-cert.sh" "$d"
 chmod +x "$d/trust-ose-cert.sh"
+
+ln -s /var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt \
+        /etc/pki/ca-trust/source/anchors/ose-service-ca.crt

--- a/jboss/container/java/certs/bash/configure.sh
+++ b/jboss/container/java/certs/bash/configure.sh
@@ -6,7 +6,7 @@ SCRIPT_DIR=$(dirname $0)
 ARTIFACTS_DIR=${SCRIPT_DIR}/artifacts
 
 # necessary for random UID user to run update-ca-certs
-chmod 777 \
+chmod g+w \
 	/etc/pki/ca-trust/extracted/openssl \
 	/etc/pki/ca-trust/extracted/java \
 	/etc/pki/ca-trust/source/anchors \

--- a/jboss/container/java/certs/bash/configure.sh
+++ b/jboss/container/java/certs/bash/configure.sh
@@ -12,8 +12,7 @@ chmod 777 \
 	/etc/pki/ca-trust/source/anchors \
 	/etc/pki/ca-trust/extracted/pem
 
-# XXX this script needs to be copied to wherever the runtime scripts go
-# trust-ose-cert.sh
-cp "${ARTIFACTS_DIR}/trust-ose-cert.sh" /opt/jboss
-chmod +x /opt/jboss/trust-ose-cert.sh
-# temp path
+d=/opt/jboss/container/java/certs
+mkdir -p "$d"
+cp "${ARTIFACTS_DIR}/trust-ose-cert.sh" "$d"
+chmod +x "$d/trust-ose-cert.sh"

--- a/jboss/container/java/certs/bash/configure.sh
+++ b/jboss/container/java/certs/bash/configure.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+# Configure module
+set -e
+
+SCRIPT_DIR=$(dirname $0)
+ARTIFACTS_DIR=${SCRIPT_DIR}/artifacts
+
+# necessary for random UID user to run update-ca-certs
+chmod 777 \
+	/etc/pki/ca-trust/extracted/openssl \
+	/etc/pki/ca-trust/extracted/java \
+	/etc/pki/ca-trust/source/anchors \
+	/etc/pki/ca-trust/extracted/pem
+
+# XXX this script needs to be copied to wherever the runtime scripts go
+# trust-ose-cert.sh
+cp "${ARTIFACTS_DIR}/trust-ose-cert.sh" /opt/jboss
+chmod +x /opt/jboss/trust-ose-cert.sh
+# temp path

--- a/jboss/container/java/certs/bash/module.yaml
+++ b/jboss/container/java/certs/bash/module.yaml
@@ -1,0 +1,8 @@
+schema_version: 1
+name: jboss.container.java.certs.bash
+version: '1.0'
+description: Trust runtime-supplied OpenShift/Kubernetes CA
+
+execute:
+- script: configure.sh
+  user: root

--- a/jboss/container/java/certs/bash/module.yaml
+++ b/jboss/container/java/certs/bash/module.yaml
@@ -3,6 +3,11 @@ name: jboss.container.java.certs.bash
 version: '1.0'
 description: Trust runtime-supplied OpenShift/Kubernetes CA
 
+envs:
+- name: JAVA_DISABLE_TRUST_OPENSHIFT_CA
+  example: true
+  description: When defined, the container will not automatically trust a CA certificate provided by OpenShift at run-time.
+
 execute:
 - script: configure.sh
   user: root

--- a/jboss/container/java/s2i/bash/artifacts/opt/jboss/container/java/s2i/s2i-core-hooks
+++ b/jboss/container/java/s2i/bash/artifacts/opt/jboss/container/java/s2i/s2i-core-hooks
@@ -5,3 +5,6 @@ source "${JBOSS_CONTAINER_UTIL_LOGGING_MODULE}/logging.sh"
 function s2i_core_env_init_hook() {
   S2I_TARGET_DATA_DIR="${S2I_TARGET_DATA_DIR:-${JAVA_DATA_DIR:-/deployments/data}}"
 }
+
+# Trust OpenShift CA, if provided
+/opt/jboss/container/java/certs/trust-ose-cert.sh

--- a/jboss/container/java/s2i/bash/module.yaml
+++ b/jboss/container/java/s2i/bash/module.yaml
@@ -19,3 +19,4 @@ modules:
   - name: jboss.container.hawkular.bash
   - name: jboss.container.jolokia.bash
   - name: jboss.container.util.logging.bash
+  - name: jboss.container.java.certs.bash


### PR DESCRIPTION
This module enables the trusting of CA certificates provided to
running containers by OpenShift.

At build-time: various system PKI paths are made world writeable-by-all,
in order that the random-UID runtime user can insert CA certificates
into the trusted store

At run-time: copy the CA file into place and invoke /usr/bin/update-ca-trust
To generate derivative trust stores (e.g. OpenSSL & Java JKS)

Signed-off-by: Jonathan Dowland <jdowland@redhat.com>


https://issues.jboss.org/browse/CLOUD-2689

Thanks for submitting your Pull Request!

Please make sure your PR meets following requirements:

- [x] Pull Request title is properly formatted: `[CLOUD-XYA] Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains description of the issue
- [x] Pull request does not include fixes for other issues than the main ticket
- [x] Attached commits represent unit of work and are properly formatted
- [x] You have read and agreed to the Developer Certificate of Origin (DCO) (see `CONTRIBUTING.md`)
- [x] Every commit contains `Signed-off-by: Your Name <yourname@redhat.com>` - use `git commit -s`
