### PR TITLE
[CLOUD-3065] Move base layer of RHBA 6.4 images from jboss-eap-6/eap64-openshift:1.8 to rhel7:7-released

### DIFF
--- a/tests/features/common.feature
+++ b/tests/features/common.feature
@@ -55,12 +55,6 @@ Feature: Openshift common tests
     And container log should contain Failed to create the user openshift
     And container log should contain Exiting...
 
-  @jboss-kieserver-6 @jboss-decisionserver-6 @jboss-processserver-6
-  Scenario: CLOUD-582, logs should not contain clustering warnings for kieserver
-    When container is ready
-    Then container log should not contain WARN Environment variable OPENSHIFT_KUBE_PING_NAMESPACE undefined
-    And container log should not contain WARN No password defined for JGroups cluster. AUTH protocol will be disabled. Please define JGROUPS_CLUSTER_PASSWORD.
-
   @jboss-decisionserver-6 @jboss-processserver-6 @jboss-webserver-3/webserver30-tomcat7-openshift @jboss-webserver-3/webserver31-tomcat7-openshift @jboss-webserver-3/webserver30-tomcat8-openshift @jboss-webserver-3/webserver31-tomcat8-openshift @rhdm-7/rhdm71-controller-openshift @rhdm-7/rhdm71-decisioncentral-openshift @rhdm-7/rhdm71-kieserver-openshift @rhpam-7/rhpam71-businesscentral-openshift @rhpam-7/rhpam71-businesscentral-monitoring-openshift @rhpam-7/rhpam71-controller-openshift @rhpam-7/rhpam71-kieserver-openshift
   Scenario: Enable Access Log
     When container is started with env


### PR DESCRIPTION
[CLOUD-3065] Move base layer of RHBA 6.4 images from jboss-eap-6/eap64-openshift:1.8 to rhel7:7-released
https://issues.jboss.org/browse/CLOUD-3065

Signed-off-by: David Ward <dward@redhat.com>

Thanks for submitting your Pull Request!

Please make sure your PR meets following requirements:

- [ ] Pull Request title is properly formatted: `[CLOUD-XYA] Subject`
- [ ] Pull Request contains link to the JIRA issue
- [ ] Pull Request contains description of the issue
- [ ] Pull request does not include fixes for other issues than the main ticket
- [ ] Attached commits represent unit of work and are properly formatted
- [ ] You have read and agreed to the Developer Certificate of Origin (DCO) (see `CONTRIBUTING.md`)
- [ ] Every commit contains `Signed-off-by: Your Name <yourname@redhat.com>` - use `git commit -s`
