### PR TITLE
[CLOUD-3168] Missing escape in context.xml sed in os-jws-secure-mgmt-console module

### DIFF
--- a/os-jws-secure-mgmt-console/run
+++ b/os-jws-secure-mgmt-console/run
@@ -7,4 +7,4 @@ ADDED_DIR=${SCRIPT_DIR}/added
 
 cp -p "$ADDED_DIR/secure-mgmt-console.sh" "$JWS_HOME/bin/launch/"
 
-sed -i -e 's#</Context>#\n   <Valve className="org.apache.catalina.valves.RemoteAddrValve" allow="127\.\d+\.\d+\.\d+|::1|0:0:0:0:0:0:0:1"/>\n</Context>#' $JWS_HOME/webapps/manager/META-INF/context.xml
+sed -i -e 's#</Context>#\n   <Valve className="org.apache.catalina.valves.RemoteAddrValve" allow="127\\.\\d+\\.\\d+\\.\\d+|::1|0:0:0:0:0:0:0:1"/>\n</Context>#' $JWS_HOME/webapps/manager/META-INF/context.xml


### PR DESCRIPTION
Thanks for submitting your Pull Request!

Please make sure your PR meets the following requirements:

- [x] Pull Request title is properly formatted: `[CLOUD-XYA] Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket
- [x] Attached commits represent units of work and are properly formatted
- [x] You have read and agreed to the Developer Certificate of Origin (DCO) (see `CONTRIBUTING.md`)
- [x] Every commit contains `Signed-off-by: Your Name <yourname@example.com>` - use `git commit -s`