### PR TITLE
[CLOUD-3272] Remove hawkular agent from OpenJDK

### DIFF
--- a/jboss/container/java/s2i/bash/artifacts/usr/local/s2i/run
+++ b/jboss/container/java/s2i/bash/artifacts/usr/local/s2i/run
@@ -19,9 +19,6 @@ if [ -f "${JBOSS_CONTAINER_JOLOKIA_MODULE}/jolokia-opts" ]; then
     # Always include jolokia-opts, which can be empty if switched off via env
     JAVA_OPTS="${JAVA_OPTS} $(${JBOSS_CONTAINER_JOLOKIA_MODULE}/jolokia-opts)"
 fi
-if [ -f "${JBOSS_CONTAINER_HAWKULAR_MODULE}/hawkular-opts" ]; then
-    JAVA_OPTS="${JAVA_OPTS} $(source ${JBOSS_CONTAINER_HAWKULAR_MODULE}/hawkular-opts && get_hawkular_opts)"
-fi
 if [ -f "${JBOSS_CONTAINER_PROMETHEUS_MODULE}/prometheus-opts" ]; then
     JAVA_OPTS="${JAVA_OPTS} $(source ${JBOSS_CONTAINER_PROMETHEUS_MODULE}/prometheus-opts && get_prometheus_opts)"
 fi

--- a/jboss/container/java/s2i/bash/module.yaml
+++ b/jboss/container/java/s2i/bash/module.yaml
@@ -16,7 +16,6 @@ modules:
   install:
   - name: jboss.container.maven.s2i.bash
   - name: jboss.container.java.run.bash
-  - name: jboss.container.hawkular.bash
   - name: jboss.container.jolokia.bash
   - name: jboss.container.prometheus.bash
   - name: jboss.container.util.logging.bash


### PR DESCRIPTION
https://issues.jboss.org/browse/CLOUD-3272

Remove the hawkular agent which does not work properly under OpenJDK 11, is likely not being used, the artefact has not been updated since October 2017, etc

- [x] Pull Request title is properly formatted: `[CLOUD-XYA] Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket
- [x] Attached commits represent units of work and are properly formatted
- [x] You have read and agreed to the Developer Certificate of Origin (DCO) (see `CONTRIBUTING.md`)
- [x] Every commit contains `Signed-off-by: Your Name <yourname@example.com>` - use `git commit -s`
