### PR TITLE
CLOUD-3270 - There is no environment variable to configure the initial metaspace size

### DIFF
--- a/jboss/container/java/jvm/api/README.adoc
+++ b/jboss/container/java/jvm/api/README.adoc
@@ -30,6 +30,7 @@ The following environment variables are used to configure the functionality prov
 |GC_ADAPTIVE_SIZE_POLICY_WEIGHT |The weighting given to the current GC time versus previous GC times. |90
 |GC_CONTAINER_OPTIONS |specify Java GC to use. The value of this variable should contain the necessary JRE command-line options to specify the required GC, which will override the default of `-XX:+UseParallelOldGC`. |-XX:+UseG1GC
 |GC_MAX_HEAP_FREE_RATIO |Maximum percentage of heap free after GC to avoid shrinking. |40
+|GC_METASPACE_SIZE |The initial metaspace size. |20
 |GC_MAX_METASPACE_SIZE |The maximum metaspace size. |100
 |GC_MIN_HEAP_FREE_RATIO |Minimum percentage of heap free after GC to avoid expansion. |20
 |GC_TIME_RATIO |Specifies the ratio of the time spent outside the garbage collection (for example, the time spent for application execution) to the time spent in the garbage collection. |4

--- a/jboss/container/java/jvm/api/module.yaml
+++ b/jboss/container/java/jvm/api/module.yaml
@@ -48,6 +48,9 @@ envs:
 - name: GC_ADAPTIVE_SIZE_POLICY_WEIGHT
   description: The weighting given to the current GC time versus previous GC times.
   example: "90"
+- name: GC_METASPACE_SIZE
+  description: The initial metaspace size.
+  example: "20"
 - name: GC_MAX_METASPACE_SIZE
   description: The maximum metaspace size.
   example: "100"

--- a/jboss/container/java/jvm/bash/artifacts/opt/jboss/container/java/jvm/java-default-options
+++ b/jboss/container/java/jvm/bash/artifacts/opt/jboss/container/java/jvm/java-default-options
@@ -137,14 +137,29 @@ gc_config() {
   local adaptiveSizePolicyWeight=${GC_ADAPTIVE_SIZE_POLICY_WEIGHT:-90}
   local maxMetaspaceSize=${GC_MAX_METASPACE_SIZE:-100}
   local gcOptions="${GC_CONTAINER_OPTIONS:--XX:+UseParallelOldGC}"
+  # for compat reasons we don't set a default value for metaspaceSize
+  local metaspaceSize
 
-  echo "$(jvm_specific_options) "\
-       "${gcOptions} " \
-       "-XX:MinHeapFreeRatio=${minHeapFreeRatio} "\
-       "-XX:MaxHeapFreeRatio=${maxHeapFreeRatio} "\
-       "-XX:GCTimeRatio=${timeRatio} "\
-       "-XX:AdaptiveSizePolicyWeight=${adaptiveSizePolicyWeight} "\
-       "-XX:MaxMetaspaceSize=${maxMetaspaceSize}m"
+  if [ -n "${GC_METASPACE_SIZE}" ]; then
+    metaspaceSize=${GC_METASPACE_SIZE}
+    # clamp the max size of metaspaceSize to be <= maxMetaspaceSize
+    if [ "${metaspaceSize}" -gt "${maxMetaspaceSize}" ]; then
+      metaspaceSize=${maxMetaspaceSize}
+    fi
+  fi
+
+  local allOptions="$(jvm_specific_options) "
+  allOptions+="${gcOptions} "
+  allOptions+="-XX:MinHeapFreeRatio=${minHeapFreeRatio} "
+  allOptions+="-XX:MaxHeapFreeRatio=${maxHeapFreeRatio} "
+  allOptions+="-XX:GCTimeRatio=${timeRatio} "
+  allOptions+="-XX:AdaptiveSizePolicyWeight=${adaptiveSizePolicyWeight} "
+  allOptions+="-XX:MaxMetaspaceSize=${maxMetaspaceSize}m "
+  if [ -n "${metaspaceSize}" ]; then
+    allOptions+="-XX:MetaspaceSize=${metaspaceSize}m "
+  fi
+
+  echo "${allOptions}"
 }
 
 error_handling() {


### PR DESCRIPTION
https://issues.jboss.org/browse/CLOUD-3270
Signed-off-by: Ken Wills <kwills@redhat.com>

Thanks for submitting your Pull Request!

Please make sure your PR meets the following requirements:

- [ ] Pull Request title is properly formatted: `[CLOUD-XYA] Subject`
- [ ] Pull Request contains link to the JIRA issue
- [ ] Pull Request contains description of the issue
- [ ] Pull Request does not include fixes for issues other than the main ticket
- [ ] Attached commits represent units of work and are properly formatted
- [ ] You have read and agreed to the Developer Certificate of Origin (DCO) (see `CONTRIBUTING.md`)
- [ ] Every commit contains `Signed-off-by: Your Name <yourname@example.com>` - use `git commit -s`
