### PR TITLE
Openj9 support

### DIFF
--- a/jboss/container/java/rm-openjdk/configure.sh
+++ b/jboss/container/java/rm-openjdk/configure.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+set -u
+set -e
+
+for pkg in java-1.8.0-openjdk-devel \
+       java-1.8.0-openjdk-headless \
+       java-1.8.0-openjdk; do
+    if rpm -q "$pkg"; then
+        rpm -e --nodeps "$pkg"
+    fi
+done

--- a/jboss/container/java/rm-openjdk/module.yaml
+++ b/jboss/container/java/rm-openjdk/module.yaml
@@ -1,0 +1,7 @@
+schema_version: 1
+name: jboss.container.java.rm-openjdk
+version: '1.0'
+description: Remove OpenJDK 1.8
+
+execute:
+- script: configure.sh

--- a/jboss/container/openjdk/jdk/openj9-11/artifacts/opt/jboss/container/openjdk/jdk/jvm-options
+++ b/jboss/container/openjdk/jdk/openj9-11/artifacts/opt/jboss/container/openjdk/jdk/jvm-options
@@ -1,0 +1,10 @@
+
+#!/bin/sh
+# ==============================================================================
+# JDK specific customizations
+#
+# ==============================================================================
+
+function jvm_specific_diagnostics() {
+    echo "-XX:NativeMemoryTracking=summary -XX:+PrintGC -XX:+PrintGCDateStamps -XX:+PrintGCTimeStamps -XX:+UnlockDiagnosticVMOptions"
+}

--- a/jboss/container/openjdk/jdk/openj9-11/artifacts/opt/jboss/container/openjdk/jdk/jvm-options
+++ b/jboss/container/openjdk/jdk/openj9-11/artifacts/opt/jboss/container/openjdk/jdk/jvm-options
@@ -6,5 +6,5 @@
 # ==============================================================================
 
 function jvm_specific_diagnostics() {
-    echo "-XX:NativeMemoryTracking=summary -XX:+PrintGC -XX:+PrintGCDateStamps -XX:+PrintGCTimeStamps -XX:+UnlockDiagnosticVMOptions"
+    echo ""
 }

--- a/jboss/container/openjdk/jdk/openj9-11/configure.sh
+++ b/jboss/container/openjdk/jdk/openj9-11/configure.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+# Configure module
+set -e
+
+SCRIPT_DIR=$(dirname $0)
+ARTIFACTS_DIR=${SCRIPT_DIR}/artifacts
+
+chown -R jboss:root $SCRIPT_DIR
+chmod -R ug+rwX $SCRIPT_DIR
+chmod ug+x ${ARTIFACTS_DIR}/opt/jboss/container/openjdk/jdk/*
+
+pushd ${ARTIFACTS_DIR}
+cp -pr * /
+popd
+
+# XXX still needed?
+# echo securerandom.source=file:/dev/urandom >> /usr/lib/jvm/java/jre/lib/security/java.security

--- a/jboss/container/openjdk/jdk/openj9-11/configure.sh
+++ b/jboss/container/openjdk/jdk/openj9-11/configure.sh
@@ -13,5 +13,17 @@ pushd ${ARTIFACTS_DIR}
 cp -pr * /
 popd
 
-# XXX still needed?
-# echo securerandom.source=file:/dev/urandom >> /usr/lib/jvm/java/jre/lib/security/java.security
+_arch="$(uname -i)"
+alternatives --set java java-11-openj9.${_arch}
+alternatives --set javac java-11-openj9.${_arch}
+alternatives --set java_sdk_openj9 java-11-openj9.${_arch}
+alternatives --set jre_openj9 java-11-openj9.${_arch}
+
+# Update securerandom.source for quicker starts (must be done after removing jdk 8, or it will hit the wrong files)
+JAVA_SECURITY_FILE=/usr/lib/jvm/java/conf/security/java.security
+SECURERANDOM=securerandom.source
+if grep -q "^$SECURERANDOM=.*" $JAVA_SECURITY_FILE; then
+    sed -i "s|^$SECURERANDOM=.*|$SECURERANDOM=file:/dev/urandom|" $JAVA_SECURITY_FILE
+else
+    echo $SECURERANDOM=file:/dev/urandom >> $JAVA_SECURITY_FILE
+fi

--- a/jboss/container/openjdk/jdk/openj9-11/module.yaml
+++ b/jboss/container/openjdk/jdk/openj9-11/module.yaml
@@ -1,0 +1,34 @@
+schema_version: 1
+
+name: "jboss.container.openjdk.jdk"
+description: "Installs the JDK for OpenJ9 11."
+version: "openj9-11"
+
+labels:
+- name: "org.jboss.product"
+  value: "openjdk"
+- name: "org.jboss.product.version"
+  value: "11"
+- name: "org.jboss.product.openjdk.version"
+  value: "11"
+
+envs:
+- name: "JAVA_HOME"
+  value: "/usr/lib/jvm/jre-11-openj9"
+- name: "JAVA_VENDOR"
+  value: "AdoptOpenJDK"
+- name: "JAVA_VERSION"
+  value: "11"
+- name: JBOSS_CONTAINER_OPENJDK_JDK_MODULE
+  value: /opt/jboss/container/openjdk/jdk
+
+packages:
+  install:
+  - java-11-openj9-devel
+
+modules:
+  install:
+  - name: jboss.container.user
+
+execute:
+- script: configure.sh

--- a/jboss/container/openjdk/jdk/openj9-11/module.yaml
+++ b/jboss/container/openjdk/jdk/openj9-11/module.yaml
@@ -19,8 +19,6 @@ envs:
   value: "AdoptOpenJDK"
 - name: "JAVA_VERSION"
   value: "11"
-- name: JBOSS_CONTAINER_OPENJDK_JDK_MODULE
-  value: /opt/jboss/container/openjdk/jdk
 
 packages:
   install:

--- a/jboss/container/openjdk/jdk/openj9-11/module.yaml
+++ b/jboss/container/openjdk/jdk/openj9-11/module.yaml
@@ -8,9 +8,9 @@ labels:
 - name: "org.jboss.product"
   value: "openjdk"
 - name: "org.jboss.product.version"
-  value: "11"
+  value: "11.0"
 - name: "org.jboss.product.openjdk.version"
-  value: "11"
+  value: "11.0"
 
 envs:
 - name: "JAVA_HOME"
@@ -18,7 +18,7 @@ envs:
 - name: "JAVA_VENDOR"
   value: "AdoptOpenJDK"
 - name: "JAVA_VERSION"
-  value: "11"
+  value: "11.0"
 
 packages:
   install:

--- a/jboss/container/openjdk/jdk/openj9-8/artifacts/opt/jboss/container/openjdk/jdk/jvm-options
+++ b/jboss/container/openjdk/jdk/openj9-8/artifacts/opt/jboss/container/openjdk/jdk/jvm-options
@@ -1,0 +1,10 @@
+
+#!/bin/sh
+# ==============================================================================
+# JDK specific customizations
+#
+# ==============================================================================
+
+function jvm_specific_diagnostics() {
+    echo "-XX:NativeMemoryTracking=summary -XX:+PrintGC -XX:+PrintGCDateStamps -XX:+PrintGCTimeStamps -XX:+UnlockDiagnosticVMOptions"
+}

--- a/jboss/container/openjdk/jdk/openj9-8/artifacts/opt/jboss/container/openjdk/jdk/jvm-options
+++ b/jboss/container/openjdk/jdk/openj9-8/artifacts/opt/jboss/container/openjdk/jdk/jvm-options
@@ -6,5 +6,5 @@
 # ==============================================================================
 
 function jvm_specific_diagnostics() {
-    echo "-XX:NativeMemoryTracking=summary -XX:+PrintGC -XX:+PrintGCDateStamps -XX:+PrintGCTimeStamps -XX:+UnlockDiagnosticVMOptions"
+    echo ""
 }

--- a/jboss/container/openjdk/jdk/openj9-8/configure.sh
+++ b/jboss/container/openjdk/jdk/openj9-8/configure.sh
@@ -13,5 +13,18 @@ pushd ${ARTIFACTS_DIR}
 cp -pr * /
 popd
 
-# XXX still needed?
-# echo securerandom.source=file:/dev/urandom >> /usr/lib/jvm/java/jre/lib/security/java.security
+# Set this JDK as the alternative in use
+_arch="$(uname -i)"
+alternatives --set java java-1.8.0-openj9.${_arch}
+alternatives --set javac java-1.8.0-openj9.${_arch}
+alternatives --set java_sdk_openj9 java-1.8.0-openj9.${_arch}
+alternatives --set jre_openj9 java-1.8.0-openj9.${_arch}
+
+# Update securerandom.source for quicker starts (must be done after removing jdk 8, or it will hit the wrong files)
+JAVA_SECURITY_FILE=/usr/lib/jvm/java/jre/lib/security/java.security
+SECURERANDOM=securerandom.source
+if grep -q "^$SECURERANDOM=.*" $JAVA_SECURITY_FILE; then
+    sed -i "s|^$SECURERANDOM=.*|$SECURERANDOM=file:/dev/urandom|" $JAVA_SECURITY_FILE
+else
+    echo $SECURERANDOM=file:/dev/urandom >> $JAVA_SECURITY_FILE
+fi

--- a/jboss/container/openjdk/jdk/openj9-8/configure.sh
+++ b/jboss/container/openjdk/jdk/openj9-8/configure.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+# Configure module
+set -e
+
+SCRIPT_DIR=$(dirname $0)
+ARTIFACTS_DIR=${SCRIPT_DIR}/artifacts
+
+chown -R jboss:root $SCRIPT_DIR
+chmod -R ug+rwX $SCRIPT_DIR
+chmod ug+x ${ARTIFACTS_DIR}/opt/jboss/container/openjdk/jdk/*
+
+pushd ${ARTIFACTS_DIR}
+cp -pr * /
+popd
+
+# XXX still needed?
+# echo securerandom.source=file:/dev/urandom >> /usr/lib/jvm/java/jre/lib/security/java.security

--- a/jboss/container/openjdk/jdk/openj9-8/module.yaml
+++ b/jboss/container/openjdk/jdk/openj9-8/module.yaml
@@ -19,8 +19,6 @@ envs:
   value: "AdoptOpenJDK"
 - name: "JAVA_VERSION"
   value: "1.8.0"
-- name: JBOSS_CONTAINER_OPENJDK_JDK_MODULE
-  value: /opt/jboss/container/openjdk/jdk
 
 packages:
   install:

--- a/jboss/container/openjdk/jdk/openj9-8/module.yaml
+++ b/jboss/container/openjdk/jdk/openj9-8/module.yaml
@@ -1,0 +1,34 @@
+schema_version: 1
+
+name: "jboss.container.openjdk.jdk"
+description: "Installs the JDK for OpenJ9 8."
+version: "openj9-8"
+
+labels:
+- name: "org.jboss.product"
+  value: "openjdk"
+- name: "org.jboss.product.version"
+  value: "1.8.0"
+- name: "org.jboss.product.openjdk.version"
+  value: "1.8.0"
+
+envs:
+- name: "JAVA_HOME"
+  value: "/usr/lib/jvm/jre-1.8.0-openj9"
+- name: "JAVA_VENDOR"
+  value: "AdoptOpenJDK"
+- name: "JAVA_VERSION"
+  value: "1.8.0"
+- name: JBOSS_CONTAINER_OPENJDK_JDK_MODULE
+  value: /opt/jboss/container/openjdk/jdk
+
+packages:
+  install:
+  - java-1.8.0-openj9-devel
+
+modules:
+  install:
+  - name: jboss.container.user
+
+execute:
+- script: configure.sh


### PR DESCRIPTION
A new module that installs OpenJ9 instead of OpenJDK.

Some things I'd like to fix:

- [ ] rename "jboss.container.openjdk.jdk"  since it can now provide OpenJ9 instead, so openjdk in the name is misleading.
- [ ] remove the "rm-openjdk" module, and instead fix whichever path is resulting in OpenJDK being installed.

