### PR TITLE
[CLOUD-3433] fix version of io:subsystem in standalone-openshift.xml

### DIFF
--- a/os-sso72/added/standalone-openshift.xml
+++ b/os-sso72/added/standalone-openshift.xml
@@ -205,7 +205,7 @@
             <default-missing-method-permissions-deny-access value="true"/>
             <log-system-exceptions value="true"/>
         </subsystem>
-        <subsystem xmlns="urn:jboss:domain:io:2.0">
+        <subsystem xmlns="urn:jboss:domain:io:3.0">
             <worker name="default"/>
             <buffer-pool name="default"/>
         </subsystem>


### PR DESCRIPTION
https://issues.jboss.org/browse/CLOUD-3433

Standalone-openshift.xml has the incorrect version of the io:subsystem

Signed-off-by: Daniel Kreling <dkreling@gmail.com>