### PR TITLE
Fix Prometheus tests and re-add Jolokia tests

### DIFF
--- a/tests/features/jolokia.feature
+++ b/tests/features/jolokia.feature
@@ -1,0 +1,10 @@
+# Tests for jboss/container/jolokia
+@openjdk
+@redhat-openjdk-18
+@openj9
+Feature: Openshift OpenJDK Jolokia tests
+
+  Scenario: Check Environment variable is correct
+    Given s2i build https://github.com/jboss-openshift/openshift-quickstarts from undertow-servlet
+    Then run sh -c 'unzip -q -p /usr/share/java/jolokia-jvm-agent/jolokia-jvm.jar META-INF/maven/org.jolokia/jolokia-jvm/pom.properties | grep -F ${JOLOKIA_VERSION}' in container and check its output for version=
+

--- a/tests/features/prometheus.feature
+++ b/tests/features/prometheus.feature
@@ -1,18 +1,20 @@
+@openjdk
+@redhat/openjdk-8-rhel7
+@openj9
 Feature: Prometheus agent tests
 
   Scenario: Verify API and defaults
     When container is started with args and env
       | arg_env                  | value |
       | env_AB_PROMETHEUS_ENABLE | false |
-      | arg_command              | bash -c 'source $JBOSS_CONTAINER_PROMETHEUS_MODULE/prometheus-opts; test -z get_prometheus_opts; echo $?' |
-    Then all files under /opt/jboss/container/prometheus are writeable by current user
-      And container log should contain 1
+      | arg_command              | bash -c 'source $JBOSS_CONTAINER_PROMETHEUS_MODULE/prometheus-opts; get_prometheus_opts' |
+    Then container log should not contain -javaagent:/opt/jboss/container/prometheus/jmx_prometheus_javaagent.jar=9799:/opt/jboss/container/prometheus/etc/jmx-exporter-config.yaml
 
   Scenario: Check Prometheus configuration
     When container is started with args and env
       | arg_env                  | value |
       | env_AB_PROMETHEUS_ENABLE | true  |
-      | arg_command              | bash -c 'source $JBOSS_CONTAINER_PROMETHEUS_MODULE/prometheus-opts; get_prometheus_opts |
+      | arg_command              | bash -c 'source $JBOSS_CONTAINER_PROMETHEUS_MODULE/prometheus-opts; get_prometheus_opts' |
     Then container log should contain -javaagent:/opt/jboss/container/prometheus/jmx_prometheus_javaagent.jar=9799:/opt/jboss/container/prometheus/etc/jmx-exporter-config.yaml
 
   Scenario: Check Prometheus custom configuration
@@ -21,5 +23,5 @@ Feature: Prometheus agent tests
       | env_AB_PROMETHEUS_ENABLE              | true                                   |
       | env_AB_PROMETHEUS_JMX_EXPORTER_PORT   | 8080                                   |
       | env_AB_PROMETHEUS_JMX_EXPORTER_CONFIG | /path/to/some/jmx-exporter-config.yaml |
-      | arg_command                           | bash -c 'source $JBOSS_CONTAINER_PROMETHEUS_MODULE/prometheus-opts; get_prometheus_opts |
+      | arg_command                           | bash -c 'source $JBOSS_CONTAINER_PROMETHEUS_MODULE/prometheus-opts; get_prometheus_opts' |
     Then container log should contain -javaagent:/opt/jboss/container/prometheus/jmx_prometheus_javaagent.jar=8080:/path/to/some/jmx-exporter-config.yaml


### PR DESCRIPTION
I don't think the Prometheus could ever have been run:

 • CeKit does not collect/run tests outside of "tests/features"
   for module sources (https://github.com/cekit/cekit/issues/638)
 • The features are not tagged
 • There are syntax errors in the features

Address all of the above. Tag the tests for execution on the
OpenJDK containers.

Also re-add the Jolokia tests, which were moved out of this repo and into the OpenJDK one, but should be here (IMHO) because this is the code that they test.

Other images are welcome to (and encouraged) to add their tags to these tests.