### PR TITLE
enable Maven 3.6 AppStream module prior to install

### DIFF
--- a/jboss/container/maven/36/default/configure.sh
+++ b/jboss/container/maven/36/default/configure.sh
@@ -1,6 +1,9 @@
 #!/bin/sh
 set -e
 
+dnf module enable -y maven:3.6
+dnf install -y --setopt=tsflags=nodocs maven
+
 # maven pulls in jdk8, so we need to remove them if another jdk is the default
 if ! readlink /etc/alternatives/java | grep -q "java-1\.8\.0"; then
     for pkg in java-1.8.0-openjdk-devel \

--- a/jboss/container/maven/36/default/module.yaml
+++ b/jboss/container/maven/36/default/module.yaml
@@ -13,10 +13,6 @@ envs:
 - name: MAVEN_VERSION
   value: "3.6"
 
-packages:
-  install:
-  - maven
-
 execute:
 - script: configure.sh
 


### PR DESCRIPTION
The AppStream module part of this commit is necessary to get access
to Maven 3.6 (instead of 3.5). The "dnf module enable" part needs
to happen before the package installation. Cekit's module ordering
places the "execute" last; so we either need to have two cekit
modules: the first to enable the AppStream module, and the second
to install the package; or (as in this commit) perform the package
installation in the script, too.

This hard-codes "dnf". However, "microdnf" does not support enabling
AppStream modules, which rules out using the minimal-flavour images
without further work.