### PR TITLE
Fix the maven 3.6 default module

### DIFF
--- a/jboss/container/maven/36/default/configure.sh
+++ b/jboss/container/maven/36/default/configure.sh
@@ -1,3 +1,6 @@
 #!/bin/sh
 set -e
 
+dnf module enable -y maven:3.6
+dnf install -y --setopt=tsflags=nodocs maven
+dnf clean all


### PR DESCRIPTION
PR #366 was a little too aggressive in removing code from configure.sh
leaving this module as (almost) a no-op. Restore the maven installation
commands.