### PR TITLE
New modules for ubi-minimal

### DIFF
--- a/jboss/container/dnf/module.yaml
+++ b/jboss/container/dnf/module.yaml
@@ -1,0 +1,8 @@
+schema_version: 1
+name: jboss.container.dnf
+version: '1.0'
+description: installs dnf
+
+packages:
+  install:
+    - dnf

--- a/jboss/container/microdnf-bz-workaround/configure.sh
+++ b/jboss/container/microdnf-bz-workaround/configure.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+mkdir -p /run/user/0

--- a/jboss/container/microdnf-bz-workaround/module.yaml
+++ b/jboss/container/microdnf-bz-workaround/module.yaml
@@ -1,0 +1,7 @@
+schema_version: 1
+name: jboss.container.microdnf-bz-workaround
+version: '1.0'
+description: workaround for BZ #1769831
+
+execute:
+- script: configure.sh


### PR DESCRIPTION
I'm using both of these modules in order to base on the ubi-minimal base image; I need to install DNF to enable the maven module; the BZ workaround is hopefully temporary.