### PR TITLE
[CLOUD-3550] Update path of Jolokia's JVM agent JAR in existing CCT tests too

### DIFF
--- a/tests/features/eap/eap_common.feature
+++ b/tests/features/eap/eap_common.feature
@@ -58,7 +58,7 @@ Feature: Openshift EAP common tests (EAP and EAP derived images)
   @jboss-decisionserver-6 @jboss-processserver-6 
   Scenario: Check if jolokia is configured correctly
     When container is ready
-    Then container log should contain -javaagent:/opt/jboss/container/jolokia/jolokia.jar=config=/opt/jboss/container/jolokia/etc/jolokia.properties
+    Then container log should contain -javaagent:/usr/share/java/jolokia-jvm-agent/jolokia-jvm.jar=config=/opt/jboss/container/jolokia/etc/jolokia.properties
 
   @redhat-sso-7/sso72-openshift @jboss-datavirt-6/datavirt63-openshift @jboss-datavirt-6/datavirt64-openshift
   Scenario: jgroups-encrypt

--- a/tests/features/sso/sso.feature
+++ b/tests/features/sso/sso.feature
@@ -58,7 +58,7 @@ Feature: OpenShift SSO tests
   # CLOUD-769
   Scenario: test jolokia started
     When container is ready
-    Then container log should contain -javaagent:/opt/jboss/container/jolokia/jolokia.jar=config=/opt/jboss/container/jolokia/etc/jolokia.properties
+    Then container log should contain -javaagent:/usr/share/java/jolokia-jvm-agent/jolokia-jvm.jar=config=/opt/jboss/container/jolokia/etc/jolokia.properties
      And available container log should not contain java.net.BindException
 
   Scenario: Test REST API is available and secure

--- a/tests/features/webserver/webserver_tomcat.feature
+++ b/tests/features/webserver/webserver_tomcat.feature
@@ -9,7 +9,7 @@ Feature: Openshift tomcat basic tests
          | property        | value                                                                          |
          | port            | 8080                                                                           | 
          | expected_phrase | If you're seeing this, you've successfully installed Tomcat. Congratulations   |
-    And container log should contain Command line argument: -javaagent:/opt/jboss/container/jolokia/jolokia.jar=config=/opt/jboss/container/jolokia/etc/jolokia.properties
+    And container log should contain Command line argument: -javaagent:/usr/share/java/jolokia-jvm-agent/jolokia-jvm.jar=config=/opt/jboss/container/jolokia/etc/jolokia.properties
     And container log should contain Command line argument: -Dfoo=test_for_me
 
   Scenario: Ensure that the manager webapp is secure


### PR DESCRIPTION
    [CLOUD-3550] Update path of Jolokia's JVM agent JAR in existing CCT tests too
    
    Recent 3bee8b7 change moved Jolokia's JVM agent JAR from former
    "/opt/jboss/container/jolokia/jolokia.jar" path to the new
    "/usr/share/java/jolokia-jvm-agent/jolokia-jvm.jar" one
    
    Update the existing CCT module Jolokia tests too, so they expect
    the new location in the pod log
    
    Signed-off-by: Jan Lieskovsky <jlieskov@redhat.com>


Thanks for submitting your Pull Request!

Please make sure your PR meets the following requirements:

- [ ] Pull Request title is properly formatted: `[CLOUD-XYA] Subject`
- [ ] Pull Request contains link to the JIRA issue
- [ ] Pull Request contains description of the issue
- [ ] Pull Request does not include fixes for issues other than the main ticket
- [ ] Attached commits represent units of work and are properly formatted
- [ ] You have read and agreed to the Developer Certificate of Origin (DCO) (see `CONTRIBUTING.md`)
- [ ] Every commit contains `Signed-off-by: Your Name <yourname@example.com>` - use `git commit -s`
