### PR TITLE
OPENJDK-84: Always clean up S2I application source

### DIFF
--- a/jboss/container/s2i/core/bash/artifacts/opt/jboss/container/s2i/core/s2i-core
+++ b/jboss/container/s2i/core/bash/artifacts/opt/jboss/container/s2i/core/s2i-core
@@ -145,16 +145,15 @@ function s2i_core_process_image_mounts() {
 }
 
 function s2i_core_cleanup() {
+  if [ -n "$(find ${S2I_SOURCE_DIR} -maxdepth 0 -type d ! -empty 2> /dev/null)" ]; then
+    log_info "Cleaning up source directory (${S2I_SOURCE_DIR})"
+    rm -rf ${S2I_SOURCE_DIR}
+  fi
   if [ "${S2I_ENABLE_INCREMENTAL_BUILDS,,}" == "true" ]; then
     return 0
   fi
   if [ -n "$(find ${S2I_ARTIFACTS_DIR} -maxdepth 0 -type d ! -empty 2> /dev/null)" ]; then
     log_info "Cleaning up artifacts directory (${S2I_ARTIFACTS_DIR})"
     rm -rf ${S2I_ARTIFACTS_DIR}
-  fi
-
-  if [ -n "$(find ${S2I_SOURCE_DIR} -maxdepth 0 -type d ! -empty 2> /dev/null)" ]; then
-    log_info "Cleaning up source directory (${S2I_SOURCE_DIR})"
-    rm -rf ${S2I_SOURCE_DIR}
   fi
 }


### PR DESCRIPTION
Do not conditionally clean it depending on whether
S2I_ENABLE_INCREMENTAL_BUILDS is set.

To resolve the application source code always remaining in /tmp after an S2I build
<https://issues.redhat.com/browse/OPENJDK-84>

At least OpenJDK and (some) JWS images are using these particular modules. I couldn't easily figure out if EAP still does — @luck3y can you confirm?

Thanks