### PR TITLE
OPENJDK-92: Remove old references to hawt-app

### DIFF
--- a/jboss/container/java/s2i/bash/artifacts/opt/jboss/container/java/s2i/maven-s2i-overrides
+++ b/jboss/container/java/s2i/bash/artifacts/opt/jboss/container/java/s2i/maven-s2i-overrides
@@ -32,10 +32,7 @@ function maven_s2i_custom_binary_build() {
 }
 
 function maven_s2i_deploy_artifacts_override() {
-  if [ ${#MAVEN_S2I_ARTIFACT_DIRS} -eq 1 -a -d "${S2I_SOURCE_DIR}/${MAVEN_S2I_ARTIFACT_DIRS[0]}/hawt-app" ]; then
-    cp -r "${S2I_SOURCE_DIR}/${MAVEN_S2I_ARTIFACT_DIRS[0]}/hawt-app"/* "${S2I_TARGET_DEPLOYMENTS_DIR}"
-    return $?
-  elif [ -n "${ARTIFACT_COPY_ARGS}" ]; then
+  if [ -n "${ARTIFACT_COPY_ARGS}" ]; then
     log_warning "ARTIFACT_COPY_ARGS is deprecated.  Please use S2I_SOURCE_DEPLOYMENTS_FILTER to specify artifact types and MAVEN_S2I_ARTIFACT_DIRS to specify the build output directories to copy from."
     if [ ! -d "${S2I_TARGET_DEPLOYMENTS_DIR}" ]; then
       log_info "S2I_TARGET_DEPLOYMENTS_DIR does not exist, creating ${S2I_TARGET_DEPLOYMENTS_DIR}"

--- a/jboss/container/maven/api/module.yaml
+++ b/jboss/container/maven/api/module.yaml
@@ -8,8 +8,8 @@ description: ^
 
 envs:
 - name: MAVEN_ARGS
-  description: Arguments to use when calling Maven, replacing the default `package hawt-app:build -DskipTests -e`. Please be sure to run the `hawt-app:build` goal (when not already bound to the `package` execution phase), otherwise the startup scripts won't work.
-  example: "-e -Popenshift -DskipTests -Dcom.redhat.xpaas.repo.redhatga package"
+  description: Arguments to use when calling Maven, replacing the default. To append additional arguments, see `MAVEN_ARGS_APPEND`.
+  example: "-e -Popenshift -DskipTests -Dcom.redhat.xpaas.repo.redhatga -Dfabric8.skip=true"
 - name: MAVEN_ARGS_APPEND
   description: Additional Maven arguments.
   example: "-X -am -pl"


### PR DESCRIPTION
https://issues.redhat.com/browse/OPENJDK-92

This is to resolve a very old (3y) issue, removing references to hawt-app that were added originally for something to do with FIS 1.0 (FIS ≥ 2 does not use hawtio, I think?)

The module YAML change is informative only; the script change has passed all the unit tests.