### PR TITLE
[CLOUD-3484] Prometheus: don't import logging.sh

### DIFF
--- a/jboss/container/prometheus/7/artifacts/opt/jboss/container/prometheus/prometheus-opts
+++ b/jboss/container/prometheus/7/artifacts/opt/jboss/container/prometheus/prometheus-opts
@@ -16,8 +16,6 @@
 #   /opt/jboss/container/prometheus/etc/jmx-exporter-config.yaml
 #
 
-source "$JBOSS_CONTAINER_UTIL_LOGGING_MODULE/logging.sh"
-
 # echo's a complete -javaagent option based on the above variables.
 function get_prometheus_opts() {
     if [ "${AB_PROMETHEUS_ENABLE^^}" = "TRUE" ]; then

--- a/jboss/container/prometheus/8.2/artifacts/opt/jboss/container/prometheus/prometheus-opts
+++ b/jboss/container/prometheus/8.2/artifacts/opt/jboss/container/prometheus/prometheus-opts
@@ -16,8 +16,6 @@
 #   /opt/jboss/container/prometheus/etc/jmx-exporter-config.yaml
 #
 
-source "$JBOSS_CONTAINER_UTIL_LOGGING_MODULE/logging.sh"
-
 # echo's a complete -javaagent option based on the above variables.
 function get_prometheus_opts() {
     if [ "${AB_PROMETHEUS_ENABLE^^}" = "TRUE" ]; then


### PR DESCRIPTION
<https://issues.redhat.com/browse/CLOUD-3484>

We were sourcing logging.sh from the module
jboss.container.util.logging.bash module but did not have a dependency
upon it. And we aren't using it anyway.