### PR TITLE
[OPENJDK-160] test for OPENJDK-84 (remove S2I-injected source post build)

### DIFF
--- a/tests/features/jboss/container/s2i/core/bash/s2i-core.feature
+++ b/tests/features/jboss/container/s2i/core/bash/s2i-core.feature
@@ -1,0 +1,9 @@
+@openjdk
+@ubi8
+@redhat-openjdk-18
+@openj9
+Feature: Openshift S2I tests
+  # OPENJDK-84 - /tmp/src should not be present after build
+  Scenario: run an s2i build and check that /tmp/src has been removed afterwards
+    Given s2i build https://github.com/jboss-openshift/openshift-examples from spring-boot-sample-simple
+    Then run stat /tmp/src in container and immediately check its output does not contain File:


### PR DESCRIPTION
tests that we remove the contents of /tmp/src after an S2I build. The code we are testing was merged here in #375 