### PR TITLE
Remove the maven.config file

### DIFF
--- a/jboss/container/maven/8.2.3.6/configure.sh
+++ b/jboss/container/maven/8.2.3.6/configure.sh
@@ -4,3 +4,4 @@ set -e
 dnf module enable -y maven:3.6
 dnf install -y --setopt=tsflags=nodocs maven
 dnf clean all
+rm -f /etc/java/maven.conf


### PR DESCRIPTION
Remove the maven.config file comes with maven 3.6 installation. This file disables the setting of $JAVA_HOME later in the container.

Please make sure your PR meets the following requirements:

- [ ] Pull Request title is properly formatted: `[CLOUD-XYA] Subject`
- [ ] Pull Request contains link to the JIRA issue
- [ ] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket
- [x] Attached commits represent units of work and are properly formatted
- [x] You have read and agreed to the Developer Certificate of Origin (DCO) (see `CONTRIBUTING.md`)
- [x] Signed-off-by: Lei Zhang <lzhan@redhat.com>
