### PR TITLE
[OPENJDK-100] set networkaddress.cache.negative.ttl=0

### DIFF
--- a/jboss/container/java/run/bash/configure.sh
+++ b/jboss/container/java/run/bash/configure.sh
@@ -16,3 +16,13 @@ popd
 mkdir -p /deployments/data \
  && chmod -R "ug+rwX" /deployments/data \
  && chown -R jboss:root /deployments/data
+
+# OPENJDK-100: turn off negative DNS caching
+if [ -w ${JAVA_HOME}/jre/lib/security/java.security ]; then
+    # JDK8 location
+    javasecurity="${JAVA_HOME}/jre/lib/security/java.security"
+else
+    # JDK11 location
+    javasecurity="${JAVA_HOME}/conf/security/java.security"
+fi
+sed -i 's/\(networkaddress.cache.negative.ttl\)=[0-9]\+$/\1=0/' "$javasecurity"

--- a/jboss/container/java/run/bash/module.yaml
+++ b/jboss/container/java/run/bash/module.yaml
@@ -56,3 +56,4 @@ modules:
   install:
   - name: jboss.container.java.jvm.bash
   - name: jboss.container.util.logging.bash
+  - name: jboss.container.openjdk.jdk

--- a/tests/features/jboss/container/java/run/bash/java.security.feature
+++ b/tests/features/jboss/container/java/run/bash/java.security.feature
@@ -1,0 +1,7 @@
+@openjdk
+@ubi8
+@redhat-openjdk-18
+Feature: Openshift S2I tests
+  Scenario: Check networkaddress.cache.negative.ttl has been set correctly
+    Given s2i build https://github.com/jboss-openshift/openshift-examples/ from binary-cli-security-property
+    Then s2i build log should contain networkaddress.cache.negative.ttl=0


### PR DESCRIPTION
Set a system property so that we do not cache negative DNS responses for
any length of time. This can interact badly with short-lived DNS names.
We can expect DNS caching to take place at the OpenShift layer anyway.

https://issues.redhat.com/browse/OPENJDK-100
