### PR TITLE
[OPENJDK-242] [JavaS2I] Maven args doesn't contain -Djkube.skip=true

### DIFF
--- a/jboss/container/maven/default/artifacts/opt/jboss/container/maven/default/maven.sh
+++ b/jboss/container/maven/default/artifacts/opt/jboss/container/maven/default/maven.sh
@@ -45,7 +45,8 @@ function maven_init_var_MAVEN_OPTS() {
 }
 
 function maven_init_var_MAVEN_ARGS() {
-  MAVEN_ARGS=${MAVEN_ARGS:--e -Popenshift -DskipTests -Dcom.redhat.xpaas.repo.redhatga -Dfabric8.skip=true}
+  # Add jkube.skip for apps that are using jkube's openshift-maven-plugin (OPENJDK-242)
+  MAVEN_ARGS=${MAVEN_ARGS:--e -Popenshift -DskipTests -Dcom.redhat.xpaas.repo.redhatga -Dfabric8.skip=true -Djkube.skip=true}
   # Use maven batch mode (CLOUD-579)
   # Always force IPv4 (CLOUD-188)
   MAVEN_ARGS="$MAVEN_ARGS --batch-mode -Djava.net.preferIPv4Stack=true"


### PR DESCRIPTION
From https://issues.redhat.com/browse/OPENJDK-242

The current Maven s2i build includes `-Dfabric8.skip=true` [1] but not `-Djkube.skip=true` [2]. JKube is the newer replacement for the fabric8 suite of tools. I think we should leave the `-Dfabric8.skip=true` for now as lots of existing workloads most likely still use this. Without this, an application wanting to use java s2i using Maven will have it's build blow up unless they add the environment variable `MAVEN_ARGS_APPEND=-Djkube.skip=true` to their build config. 

[1] https://github.com/jboss-openshift/cct_module/blob/master/jboss/container/maven/default/artifacts/opt/jboss/container/maven/default/maven.sh#L48
[2] https://www.eclipse.org/jkube/docs/openshift-maven-plugin#build-goal-configuration

Thanks for submitting your Pull Request!

Please make sure your PR meets the following requirements:

- [ ] Pull Request title is properly formatted: `[CLOUD-XYA] Subject`
- [ ] Pull Request contains link to the JIRA issue
- [ ] Pull Request contains description of the issue
- [ ] Pull Request does not include fixes for issues other than the main ticket
- [ ] Attached commits represent units of work and are properly formatted
- [ ] You have read and agreed to the Developer Certificate of Origin (DCO) (see `CONTRIBUTING.md`)
- [ ] Every commit contains `Signed-off-by: Your Name <yourname@example.com>` - use `git commit -s`
