### PR TITLE
[OPENJDK-256] Add findutils package dependency to some modules

### DIFF
--- a/jboss/container/maven/default/module.yaml
+++ b/jboss/container/maven/default/module.yaml
@@ -20,3 +20,7 @@ modules:
   - name: jboss.container.java.jvm.bash
   - name: jboss.container.maven
   - name: jboss.container.util.logging.bash
+
+packages:
+  install:
+  - findutils

--- a/jboss/container/s2i/core/bash/module.yaml
+++ b/jboss/container/s2i/core/bash/module.yaml
@@ -13,3 +13,7 @@ execute:
 modules:
   install:
   - name: jboss.container.s2i.core.api
+
+packages:
+  install:
+  - findutils


### PR DESCRIPTION
<https://issues.redhat.com/browse/OPENJDK-256>

These four modules invoke "find" in their scripts:

    1) jboss.container.java.s2i.bash
    2) jboss.container.maven.s2i
    3) jboss.container.s2i.core.bash
    4) jboss.container.maven.default

1) depends upon 2) depends upon 3) & 4), but there's no
dependency relationship between 3) & 4).

Add a package dependency on "findutils" to 3) & 4).

If a container (such as ubi8/openjdk-8) uses both of 3) & 4),
the build process will attempt to install findutil twice. This
slows the build down, but is otherwise benign.

(Some other modules also invoke "find", but they are either
product specific or legacy modules, so I have not touched them.)

- [x] Pull Request title is properly formatted: `[CLOUD-XYA] Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket
- [x] Attached commits represent units of work and are properly formatted
- [x] You have read and agreed to the Developer Certificate of Origin (DCO) (see `CONTRIBUTING.md`)
- [x] Every commit contains `Signed-off-by: Your Name <yourname@example.com>` - use `git commit -s`
