### PR TITLE
Enable maven AppStream module via conf file

### DIFF
--- a/jboss/container/maven/8.2.3.6.8/configure.sh
+++ b/jboss/container/maven/8.2.3.6.8/configure.sh
@@ -1,6 +1,0 @@
-#!/bin/sh
-set -e
-
-dnf module enable -y maven:3.6
-dnf install -y --setopt=tsflags=nodocs maven-openjdk8
-dnf clean all

--- a/jboss/container/maven/8.2.3.6.8/module.yaml
+++ b/jboss/container/maven/8.2.3.6.8/module.yaml
@@ -14,5 +14,10 @@ envs:
 - name: MAVEN_VERSION
   value: "3.6"
 
-execute:
-- script: configure.sh
+modules:
+  install:
+  - name: jboss.container.maven.module
+
+packages:
+  install:
+  - maven-openjdk8

--- a/jboss/container/maven/8.2.3.6/configure.sh
+++ b/jboss/container/maven/8.2.3.6/configure.sh
@@ -1,7 +1,0 @@
-#!/bin/sh
-set -e
-
-dnf module enable -y maven:3.6
-dnf install -y --setopt=tsflags=nodocs maven
-dnf clean all
-rm -f /etc/java/maven.conf

--- a/jboss/container/maven/8.2.3.6/module.yaml
+++ b/jboss/container/maven/8.2.3.6/module.yaml
@@ -13,5 +13,10 @@ envs:
 - name: MAVEN_VERSION
   value: "3.6"
 
-execute:
-- script: configure.sh
+modules:
+  install:
+  - name: jboss.container.maven.module
+
+packages:
+  install:
+  - maven

--- a/jboss/container/maven/module/artifacts/maven.module
+++ b/jboss/container/maven/module/artifacts/maven.module
@@ -1,0 +1,5 @@
+[maven]
+name=maven
+stream=3.6
+profiles=
+state=enabled

--- a/jboss/container/maven/module/configure.sh
+++ b/jboss/container/maven/module/configure.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+set -e
+
+SCRIPT_DIR=$(dirname $0)
+ARTIFACTS_DIR=${SCRIPT_DIR}/artifacts
+
+cp ${ARTIFACTS_DIR}/maven.module /etc/dnf/modules.d/maven.module

--- a/jboss/container/maven/module/module.yaml
+++ b/jboss/container/maven/module/module.yaml
@@ -1,0 +1,8 @@
+schema_version: 1
+name: jboss.container.maven.module
+version: '3.6'
+description: ^
+  Enables the AppStream RPM Module for Maven 3.6 packages.
+
+execute:
+- script: configure.sh


### PR DESCRIPTION
By providing /etc/dnf/modules.d/maven.module before attempting to
install Maven, we can get access to Maven 3.6 from the AppStream
repository without having to enable the module with full-fat DNF.
This means we can install Maven 3.6 with microdnf.

The maven.module file has to be in-place before attempting to install
Maven. Since CeKit processes "packages:" before "execute:" within the
context of a module, we need to put the new "execute:" stuff in a new
module that is depended upon by those that use "packages:" to install
maven.