### PR TITLE
[OPENJDK-309] Add explicit dependency on "which"

### DIFF
--- a/jboss/container/java/run/bash/module.yaml
+++ b/jboss/container/java/run/bash/module.yaml
@@ -57,3 +57,7 @@ modules:
   - name: jboss.container.java.jvm.bash
   - name: jboss.container.util.logging.bash
   - name: jboss.container.openjdk.jdk
+
+packages:
+  install:
+    - which


### PR DESCRIPTION
run-java.sh calls "which", from RPM package "which", in some
circumstances. Record this dependency explicitly.

https://issues.redhat.com/browse/OPENJDK-309