### PR TITLE
[CLOUD-3951] Bump default maven version to 3.6

### DIFF
--- a/jboss/container/maven/8.2.3.6.8/module.yaml
+++ b/jboss/container/maven/8.2.3.6.8/module.yaml
@@ -1,6 +1,7 @@
 schema_version: 1
-name: jboss.container.maven.36.bash
-version: '3.6'
+name: jboss.container.maven
+# Version scheme: RHEL major . RHEL minor . Maven major . Maven minor . JDK version
+version: '8.2.3.6.8'
 description: Provides Maven v3.6 capabilities to an image.
 
 labels:
@@ -19,8 +20,4 @@ modules:
 
 packages:
   install:
-  - maven
-
-execute:
-- script: configure.sh
-
+  - maven-openjdk8

--- a/jboss/container/maven/default/bash/README.adoc
+++ b/jboss/container/maven/default/bash/README.adoc
@@ -52,7 +52,7 @@ The following modules will be installed with this module:
 
 link:../../../../../jboss/container/java/jvm/bash/README.adoc[jboss.container.java.jvm.bash]
 
-link:../../../../../jboss/container/maven/35/bash/README.adoc[jboss.container.maven.35.bash]
+link:../../../../../jboss/container/maven/36/bash/README.adoc[jboss.container.maven.36.bash]
 
 link:../../../../../jboss/container/maven/api/README.adoc[jboss.container.maven.api]
 

--- a/jboss/container/maven/default/bash/configure.sh
+++ b/jboss/container/maven/default/bash/configure.sh
@@ -16,7 +16,7 @@ cp -pr * /
 popd
 
 # pull in specific maven version to serve as default
-ln -s /opt/jboss/container/maven/35/* /opt/jboss/container/maven/default
+ln -s /opt/jboss/container/maven/36/* /opt/jboss/container/maven/default
 chown -h jboss:root /opt/jboss/container/maven/default/*
 
 # install default settings.xml file in user home

--- a/jboss/container/maven/default/bash/module.yaml
+++ b/jboss/container/maven/default/bash/module.yaml
@@ -18,5 +18,5 @@ modules:
   install:
   - name: jboss.container.maven.api
   - name: jboss.container.java.jvm.bash
-  - name: jboss.container.maven.35.bash
+  - name: jboss.container.maven.36.bash
   - name: jboss.container.util.logging.bash

--- a/jboss/container/maven/module/artifacts/maven.module
+++ b/jboss/container/maven/module/artifacts/maven.module
@@ -1,0 +1,5 @@
+[maven]
+name=maven
+stream=3.6
+profiles=
+state=enabled

--- a/jboss/container/maven/module/configure.sh
+++ b/jboss/container/maven/module/configure.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+set -e
+
+SCRIPT_DIR=$(dirname $0)
+ARTIFACTS_DIR=${SCRIPT_DIR}/artifacts
+
+cp ${ARTIFACTS_DIR}/maven.module /etc/dnf/modules.d/maven.module

--- a/jboss/container/maven/module/module.yaml
+++ b/jboss/container/maven/module/module.yaml
@@ -1,0 +1,8 @@
+schema_version: 1
+name: jboss.container.maven.module
+version: '3.6'
+description: ^
+  Enables the AppStream RPM Module for Maven 3.6 packages.
+
+execute:
+- script: configure.sh


### PR DESCRIPTION
Maven 3.5 has reached EOL and requires upgrade.

https://issues.redhat.com/browse/CLOUD-3951
Signed-off-by: Daniel Kreling <dkreling@redhat.com>