### PR TITLE
ubi-clean module

### DIFF
--- a/jboss/container/util/ubi-clean/configure.sh
+++ b/jboss/container/util/ubi-clean/configure.sh
@@ -1,5 +1,12 @@
 #!/bin/sh
 
+# This list of packages was arrived at by running the following in a
+# UBI/OpenJDK container, in an environment *without any redhat entitlements* to
+# be sure the repodata is ONLY that available via normal UBI channels and not
+# the wider RHEL8 or anything else:
+#   rpm -qa --queryformat "%{NAME}\n" \
+#   | while read pkg; do microdnf repoquery $pkg 2>/dev/null | grep -q $pkg || echo $pkg; done
+
 microdnf remove grub2-common \
     dejavu-sans-mono-fonts \
     memstrack \

--- a/jboss/container/util/ubi-clean/configure.sh
+++ b/jboss/container/util/ubi-clean/configure.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+microdnf remove grub2-common \
+    dejavu-sans-mono-fonts \
+    memstrack \
+    os-prober \
+    grub2-tools \
+    grubby \
+    rpm-plugin-systemd-inhibit \
+    grub2-tools-minimal \

--- a/jboss/container/util/ubi-clean/module.yaml
+++ b/jboss/container/util/ubi-clean/module.yaml
@@ -1,0 +1,7 @@
+schema_version: 1
+name: jboss.container.util.ubi-clean
+version: '1.0'
+description: Remove a set of non-UBI RPMs (see OPENJDK-407)
+
+execute:
+- script: configure.sh


### PR DESCRIPTION
This is a new module that removes a static list of RPMs.

The list of RPMs was determined by executing the following within the currently-shipped ubi8/openjdk-11, on a host without redhat entitlements (important): 

```
rpm -qa --queryformat "%{NAME}\n" \
    | while read pkg; do microdnf repoquery $pkg 2>/dev/null | grep -q $pkg || echo $pkg; done
```

Unfortunately we cannot run this at container build-time, because it relies upon non-UBI RPMs not being in a configured dnf repository. 