### PR TITLE
CLOUD-4075 Upgrade Jolokia to 1.7.1

### DIFF
--- a/jboss/container/jolokia/7/module.yaml
+++ b/jboss/container/jolokia/7/module.yaml
@@ -8,12 +8,12 @@ description: ^
 
 labels:
 - name: io.fabric8.s2i.version.jolokia
-  value: "1.6.2-redhat-00002"
+  value: "1.7.1.redhat-00001"
 
 envs:
 - name: JOLOKIA_VERSION
   description: Version of Jolokia being used.
-  value: "1.6.2"
+  value: "1.7.1"
 - name: AB_JOLOKIA_PASSWORD_RANDOM
   description: Determines if a random AB_JOLOKIA_PASSWORD be generated. Set to **true** to generate random password. Generated value will be written to `/opt/jolokia/etc/jolokia.pw`.
   value: "true"
@@ -62,5 +62,5 @@ execute:
 
 artifacts:
 - name: jolokia-jvm
-  target: jolokia-jvm-1.6.2.redhat-00002-agent.jar
-  md5: 760f2fbaf6b142192f3cee2c99bfcbf8
+  target: jolokia-jvm-1.7.1.redhat-00001-agent.jar
+  md5: d97687fe4abef717735c3c1f4faf5f9b

--- a/jboss/container/jolokia/8.2/module.yaml
+++ b/jboss/container/jolokia/8.2/module.yaml
@@ -8,12 +8,12 @@ description: ^
 
 labels:
 - name: io.fabric8.s2i.version.jolokia
-  value: "1.6.2-redhat-00002"
+  value: "1.7.1.redhat-00001"
 
 envs:
 - name: JOLOKIA_VERSION
   description: Version of Jolokia being used.
-  value: "1.6.2"
+  value: "1.7.1"
 - name: AB_JOLOKIA_PASSWORD_RANDOM
   description: Determines if a random AB_JOLOKIA_PASSWORD be generated. Set to **true** to generate random password. Generated value will be written to `/opt/jolokia/etc/jolokia.pw`.
   value: "true"


### PR DESCRIPTION
https://issues.redhat.com/browse/CLOUD-4075
https://issues.redhat.com/browse/JBEAP-23179

Upgrade Jolokia to 1.7.1 to include fixes for JDK 9+

Signed-off-by: Tomas Hofman [thofman@redhat.com](mailto:thofman@redhat.com)

Downstream for https://github.com/jboss-openshift/cct_module/pull/415