### PR TITLE
[0.39.x] CLOUD-4075 Upgrade Jolokia to 1.7.1

### DIFF
--- a/jboss/container/jolokia/api/module.yaml
+++ b/jboss/container/jolokia/api/module.yaml
@@ -10,7 +10,7 @@ description: ^
 envs:
 - name: JOLOKIA_VERSION
   description: Version of Jolokia being used.
-  example: "1.5.0"
+  example: "1.7.1"
 - name: AB_JOLOKIA_PASSWORD_RANDOM
   description: Determines if a random AB_JOLOKIA_PASSWORD be generated. Set to **true** to generate random password. Generated value will be written to `/opt/jolokia/etc/jolokia.pw`.
   value: "true"

--- a/jboss/container/jolokia/bash/README.adoc
+++ b/jboss/container/jolokia/bash/README.adoc
@@ -19,7 +19,7 @@ toc::[]
 
 The following labels will be defined on the image:
 
-io.fabric8.s2i.version.jolokia:: 1.5.0-redhat-1
+io.fabric8.s2i.version.jolokia:: 1.7.1.redhat-00001
 
 == Environment Variables
 
@@ -36,7 +36,7 @@ The following environment variables will be configured on the image:
 |AB_JOLOKIA_HTTPS |true
 |AB_JOLOKIA_PASSWORD_RANDOM |true
 |JBOSS_CONTAINER_JOLOKIA_MODULE |/opt/jboss/container/jolokia
-|JOLOKIA_VERSION |1.5.0
+|JOLOKIA_VERSION |1.7.1
 |=======================================================================
 
 == Resources
@@ -44,10 +44,10 @@ The following environment variables will be configured on the image:
 The following resources will be included through this module:
 |=======================================================================
 |Name |Location |Checksum
-|jolokia-jvm-1.5.0.redhat-1-agent.jar 
-|https://maven.repository.redhat.com/ga/org/jolokia/jolokia-jvm/1.5.0.redhat-1/jolokia-jvm-1.5.0.redhat-1-agent.jar 
+|jolokia-jvm-1.7.1.redhat-00001-agent.jar
+|https://maven.repository.redhat.com/ga/org/jolokia/jolokia-jvm/1.7.1.redhat-00001/jolokia-jvm-1.7.1.redhat-00001.jar
 a|
-md5:: d31c6b1525e6d2d24062ef26a9f639a8
+md5:: d97687fe4abef717735c3c1f4faf5f9b
 
 sha1:: 
 

--- a/jboss/container/jolokia/bash/module.yaml
+++ b/jboss/container/jolokia/bash/module.yaml
@@ -32,8 +32,8 @@ execute:
 
 artifacts:
 - name: jolokia-jvm
-  target: jolokia-jvm-1.6.2.redhat-00002-agent.jar
-  md5: 760f2fbaf6b142192f3cee2c99bfcbf8
+  target: jolokia-jvm-1.7.1.redhat-00001-agent.jar
+  md5: d97687fe4abef717735c3c1f4faf5f9b
 
 modules:
   install:


### PR DESCRIPTION
https://issues.redhat.com/browse/CLOUD-4075
https://issues.redhat.com/browse/JBEAP-23179

Upgrade Jolokia to 1.7.1 to include fixes for JDK 9+

Signed-off-by: Tomas Hofman [thofman@redhat.com](mailto:thofman@redhat.com)

Downstream for https://github.com/jboss-openshift/cct_module/pull/415