### PR TITLE
CLOUD-4176 Upgrade jmx_prometheus_javaagent to 0.3.2.redhat-00005

### DIFF
--- a/jboss/container/prometheus/7/module.yaml
+++ b/jboss/container/prometheus/7/module.yaml
@@ -25,5 +25,5 @@ execute:
 
 artifacts:
 - name: jmx_prometheus_javaagent
-  target: jmx_prometheus_javaagent-0.3.2.redhat-00003.jar
-  md5: 8b3af39995b113baf35e53468bad7aae
+  target: jmx_prometheus_javaagent-0.3.2.redhat-00005.jar
+  md5: 2cd8f7055b99fff305a74b0581e8ecd3


### PR DESCRIPTION
https://issues.redhat.com/browse/CLOUD-4176

Upgrade jmx_prometheus_javaagent to 0.3.2.redhat-00005 to include fixes for:
https://access.redhat.com/security/cve/CVE-2022-38752
https://access.redhat.com/security/cve/CVE-2022-41854

Signed-off-by: Ruben Novelli [rnovelli@redhat.com](mailto:rnovelli@redhat.com)
