### PR TITLE
feat: allow users to disable the GC overrides

### DIFF
--- a/jboss/container/java/jvm/api/module.yaml
+++ b/jboss/container/java/jvm/api/module.yaml
@@ -58,6 +58,9 @@ envs:
   description: specify Java GC to use. The value of this variable should contain the necessary JRE command-line options to specify the required GC, which will override the default of `-XX:+UseParallelOldGC`.
   example: -XX:+UseG1GC
 # deprecated
+- name: DISABLE_GC_OVERRIDES
+  description: if nonempty, disable the GC overrides by the startup scripts: all GC_* variables above are ignored, and the scripts do not add any GC option in the java commandline.
+  example: "true"
 - name: JAVA_OPTIONS
   description: JVM options passed to the `java` command.  Use **JAVA_OPTS**.
   example: "-verbose:class"

--- a/jboss/container/java/jvm/bash/artifacts/opt/jboss/container/java/jvm/java-default-options
+++ b/jboss/container/java/jvm/bash/artifacts/opt/jboss/container/java/jvm/java-default-options
@@ -17,10 +17,13 @@
 #                     given to the container is used as the maximum heap memory with
 #                     '-Xmx'. It is a heuristic and should be better backed up with real
 #                     experiments and measurements.
-#                     For a good overviews what tuning options are available -->
-#                             https://youtu.be/Vt4G-pHXfs4
-#                             https://www.youtube.com/watch?v=w1rZOY5gbvk
-#                             https://vimeo.com/album/4133413/video/181900266
+# DISABLE_GC_OVERRIDES: if set to a nonempty value,
+#                       disable this script's overrides of the JDK defaults.
+#
+# For a good overviews what tuning options are available -->
+#         https://youtu.be/Vt4G-pHXfs4
+#         https://www.youtube.com/watch?v=w1rZOY5gbvk
+#         https://vimeo.com/album/4133413/video/181900266
 # Also note that heap is only a small portion of the memory used by a JVM. There are lot
 # of other memory areas (metadata, thread, code cache, ...) which addes to the overall
 # size. There is no easy solution for this, 50% seems to be are reasonable compromise.
@@ -131,6 +134,9 @@ cpu_core_tunning() {
 }
 
 gc_config() {
+  if [ -n "$DISABLE_GC_OVERRIDES" ]; then
+    return
+  fi
   local minHeapFreeRatio=${GC_MIN_HEAP_FREE_RATIO:-10}
   local maxHeapFreeRatio=${GC_MAX_HEAP_FREE_RATIO:-20}
   local timeRatio=${GC_TIME_RATIO:-4}


### PR DESCRIPTION
New knob (env var) DISABLE_GC_OVERRIDES: if set to a nonempty value, disable this script's overrides of the JDK defaults.

This is useful for users who want to more closely follow the JDK's defaults, or want to be free to override GC settings in another env var.

Thanks for submitting your Pull Request!

Please make sure your PR meets the following requirements:

-  Pull Request title is properly formatted: `[CLOUD-XYA] Subject`: N/A
-  Pull Request contains link to the JIRA issue: N/A
- [X] Pull Request contains description of the issue
- [X] Pull Request does not include fixes for issues other than the main ticket
- [X] Attached commits represent units of work and are properly formatted
- [X] You have read and agreed to the Developer Certificate of Origin (DCO) (see `CONTRIBUTING.md`)
- [X] Every commit contains `Signed-off-by: Your Name <yourname@example.com>` - use `git commit -s`
